### PR TITLE
Improve classification quality: temperature=0, few-shot examples, preview gating, rubric lint

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -252,6 +252,12 @@ jobs:
           pip install -r requirements.txt
           python -m pytest -v || true
 
+      - name: Test status_handler
+        working-directory: backend/status_handler
+        run: |
+          pip install boto3
+          python -m pytest -v
+
   test-frontend:
     name: Test Frontend
     runs-on: ubuntu-latest

--- a/backend/row_processor/handler.py
+++ b/backend/row_processor/handler.py
@@ -250,6 +250,69 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                                 }
                             })
                         }
+                # Optional few-shot examples: each must pair a comment with a label
+                # and the label must reference a defined option value.
+                examples = col.get('examples') or []
+                MAX_EXAMPLES_PER_COLUMN = 5
+                MAX_EXAMPLE_TEXT_LENGTH = 2000
+                if len(examples) > MAX_EXAMPLES_PER_COLUMN:
+                    return {
+                        'statusCode': 400,
+                        'headers': {
+                            'Content-Type': 'application/json',
+                            'Access-Control-Allow-Origin': _cors_origin()
+                        },
+                        'body': json.dumps({
+                            'error': {
+                                'code': 'TOO_MANY_EXAMPLES',
+                                'message': f'Each categorized column may have at most {MAX_EXAMPLES_PER_COLUMN} examples'
+                            }
+                        })
+                    }
+                valid_option_values = {o['value'] for o in options}
+                for ex in examples:
+                    if not ex.get('commentText') or not ex.get('label'):
+                        return {
+                            'statusCode': 400,
+                            'headers': {
+                                'Content-Type': 'application/json',
+                                'Access-Control-Allow-Origin': _cors_origin()
+                            },
+                            'body': json.dumps({
+                                'error': {
+                                    'code': 'INVALID_EXAMPLE',
+                                    'message': 'Each example must have both commentText and label'
+                                }
+                            })
+                        }
+                    if ex['label'] not in valid_option_values:
+                        return {
+                            'statusCode': 400,
+                            'headers': {
+                                'Content-Type': 'application/json',
+                                'Access-Control-Allow-Origin': _cors_origin()
+                            },
+                            'body': json.dumps({
+                                'error': {
+                                    'code': 'INVALID_EXAMPLE',
+                                    'message': f"Example label '{ex['label']}' is not one of the column's option values"
+                                }
+                            })
+                        }
+                    if len(ex['commentText']) > MAX_EXAMPLE_TEXT_LENGTH:
+                        return {
+                            'statusCode': 400,
+                            'headers': {
+                                'Content-Type': 'application/json',
+                                'Access-Control-Allow-Origin': _cors_origin()
+                            },
+                            'body': json.dumps({
+                                'error': {
+                                    'code': 'EXAMPLE_TEXT_TOO_LONG',
+                                    'message': f'Example commentText must be {MAX_EXAMPLE_TEXT_LENGTH} characters or fewer'
+                                }
+                            })
+                        }
             else:
                 if not col.get('instructions'):
                     return {
@@ -876,6 +939,7 @@ def _process_single_row(row: Dict[str, str],
     # Build per-column instructions, differentiating open_text vs categorized
     analysis_instructions_parts = []
     categorized_columns = {}  # col_name -> list of valid option values
+    examples_blocks = []      # rendered <examples> blocks for each column that has them
     for col in analysis_columns:
         col_type = col.get('type', 'open_text')
         if col_type == 'categorized' and col.get('options'):
@@ -888,12 +952,23 @@ def _process_single_row(row: Dict[str, str],
                 f"- {col['name']}: You MUST respond with EXACTLY one of the following values (no other text):\n{options_text}"
             )
             categorized_columns[col['name']] = [opt['value'] for opt in options]
+
+            col_examples = col.get('examples') or []
+            if col_examples:
+                rendered = "\n".join([
+                    f'  <example>\n    <comment>{_sanitize_for_prompt(str(ex["commentText"]))}</comment>\n    <{col["name"]}>{ex["label"]}</{col["name"]}>\n  </example>'
+                    for ex in col_examples
+                ])
+                examples_blocks.append(
+                    f'For column "{col["name"]}", here are correctly-classified examples:\n<examples>\n{rendered}\n</examples>'
+                )
         else:
             analysis_instructions_parts.append(
                 f"- {col['name']}: {col['instructions']}"
             )
-    
+
     analysis_instructions = "\n".join(analysis_instructions_parts)
+    examples_section = ("\n\n" + "\n\n".join(examples_blocks)) if examples_blocks else ""
     
     # Construct prompt with injection-resistant framing
     sanitized_context = _sanitize_for_prompt(context_description) if context_description else None
@@ -901,7 +976,7 @@ def _process_single_row(row: Dict[str, str],
     if sanitized_context:
         prompt_preamble += f"\n\n<context_description>{sanitized_context}</context_description>"
 
-    prompt = f"""{prompt_preamble}
+    prompt = f"""{prompt_preamble}{examples_section}
 
 <comment_data>
 {comment_text}
@@ -912,26 +987,33 @@ Please provide the following analysis:
 
 Respond in JSON format with keys matching the column names exactly. Only include the JSON object, no other text."""
     
-    # Call Bedrock with retry logic
+    # Call Bedrock with retry logic.
+    # When any categorized column is present we pin temperature=0 so that classifications
+    # are deterministic across re-runs — open-text-only runs keep Bedrock's default to
+    # preserve summary variety.
+    request_body = {
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 500,
+        "messages": [
+            {
+                "role": "user",
+                "content": prompt
+            }
+        ]
+    }
+    if categorized_columns:
+        request_body["temperature"] = 0
+
     max_retries = 3
     last_error = None
-    
+
     for attempt in range(max_retries):
         try:
             response = _get_bedrock_runtime().invoke_model(
                 modelId=CLAUDE_HAIKU_MODEL_ID,
                 contentType="application/json",
                 accept="application/json",
-                body=json.dumps({
-                    "anthropic_version": "bedrock-2023-05-31",
-                    "max_tokens": 500,
-                    "messages": [
-                        {
-                            "role": "user",
-                            "content": prompt
-                        }
-                    ]
-                })
+                body=json.dumps(request_body)
             )
             
             # Parse response
@@ -1129,6 +1211,7 @@ Respond with ONLY the chosen value, no JSON, no quotes, no explanation. Just the
                     body=json.dumps({
                         "anthropic_version": "bedrock-2023-05-31",
                         "max_tokens": 50,
+                        "temperature": 0,
                         "messages": [
                             {"role": "user", "content": retry_prompt}
                         ]

--- a/backend/row_processor/handler.py
+++ b/backend/row_processor/handler.py
@@ -37,6 +37,21 @@ JOBS_TABLE_NAME = os.environ.get('JOBS_TABLE')
 CONCURRENT_WORKERS = 500  # Process up to 500 rows concurrently
 CLAUDE_HAIKU_MODEL_ID = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
 
+# Preview-step constants. The preview phase runs the model on the first N rows
+# of a categorized job so the user can sanity-check classifications before
+# committing the full run. Skipped for files smaller than the threshold (the
+# overhead isn't worth it) and for open-text-only runs (no rubric to validate).
+PREVIEW_ROW_COUNT = 20
+PREVIEW_MIN_FILE_SIZE = 50
+
+
+def _should_use_preview(analysis_columns: List[Dict[str, Any]], total_rows: int) -> bool:
+    """Decide whether to run a preview phase before processing the full file."""
+    if total_rows < PREVIEW_MIN_FILE_SIZE:
+        return False
+    has_categorized = any(col.get('type') == 'categorized' for col in analysis_columns)
+    return has_categorized
+
 
 def _cors_origin() -> str:
     """Return the allowed CORS origin from environment, falling back to '*'."""
@@ -102,10 +117,18 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     if event.get('asyncProcessing'):
         return _process_async(event, context)
 
+    # API Gateway routes the preview-confirm path here too — detect via pathParameters.
+    # Validate the access key check applies to all API Gateway invocations.
+    path_params = event.get('pathParameters') or {}
+    if path_params.get('jobId'):
+        if not validate_access_key(event):
+            return build_unauthorized_response(_cors_origin())
+        return _handle_preview_confirm(event, context, path_params['jobId'])
+
     # Validate access key for API Gateway invocations
     if not validate_access_key(event):
         return build_unauthorized_response(_cors_origin())
-    
+
     # This is an API Gateway invocation - create job and return immediately
     try:
         # Parse request body
@@ -415,11 +438,13 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             lambda_client = boto3.client('lambda', endpoint_url=local_endpoint, use_ssl=False)
         else:
             lambda_client = boto3.client('lambda')
+        phase = 'preview' if _should_use_preview(analysis_columns, row_count) else 'full'
         lambda_client.invoke(
             FunctionName=context.function_name,
             InvocationType='Event',  # Async invocation
             Payload=json.dumps({
                 'asyncProcessing': True,
+                'phase': phase,
                 'jobId': job_id,
                 'fileId': file_id,
                 'fileType': file_type,
@@ -511,6 +536,94 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         }
 
 
+def _handle_preview_confirm(event: Dict[str, Any], context: Any, job_id: str) -> Dict[str, Any]:
+    """Handle POST /process/{jobId}/preview-confirm: validate state, then async-invoke
+    the row processor to run the full file."""
+    headers = {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': _cors_origin()
+    }
+
+    try:
+        uuid.UUID(job_id, version=4)
+    except ValueError:
+        return {
+            'statusCode': 400,
+            'headers': headers,
+            'body': json.dumps({'error': {
+                'code': 'INVALID_FILE_ID',
+                'message': 'jobId must be a valid UUID'
+            }})
+        }
+
+    try:
+        table = _get_dynamodb().Table(JOBS_TABLE_NAME)
+        result = table.get_item(Key={'jobId': job_id})
+        item = result.get('Item')
+    except ClientError as e:
+        logger.error(f"DynamoDB error fetching job {job_id}: {e}")
+        return {
+            'statusCode': 500,
+            'headers': headers,
+            'body': json.dumps({'error': {'code': 'AWS_ERROR',
+                                          'message': 'Failed to retrieve job state.'}})
+        }
+
+    if not item:
+        return {
+            'statusCode': 404,
+            'headers': headers,
+            'body': json.dumps({'error': {'code': 'JOB_NOT_FOUND',
+                                          'message': 'Job not found.'}})
+        }
+
+    if item.get('status') != 'preview_ready':
+        return {
+            'statusCode': 409,
+            'headers': headers,
+            'body': json.dumps({'error': {
+                'code': 'INVALID_JOB_STATE',
+                'message': f"Job is in state '{item.get('status')}', expected 'preview_ready'."
+            }})
+        }
+
+    # Re-derive the file type from the stored input key (e.g. uploads/<id>/input.csv)
+    input_key = item['inputFileKey']
+    file_type = input_key.rsplit('.', 1)[-1] if '.' in input_key else 'csv'
+
+    payload = {
+        'asyncProcessing': True,
+        'phase': 'confirm',
+        'jobId': job_id,
+        'fileId': item['fileId'],
+        'fileType': file_type,
+        'selectedCommentColumn': item.get('selectedCommentColumn'),
+        'contextDescription': item.get('contextDescription'),
+        'analysisColumns': item['analysisColumns'],
+        'inputKey': input_key,
+        'outputKey': item['outputFileKey']
+    }
+
+    local_endpoint = os.environ.get('LOCAL_LAMBDA_ENDPOINT')
+    if not local_endpoint and os.environ.get('AWS_SAM_LOCAL') == 'true':
+        local_endpoint = 'http://host.docker.internal:3001'
+    if local_endpoint:
+        lambda_client = boto3.client('lambda', endpoint_url=local_endpoint, use_ssl=False)
+    else:
+        lambda_client = boto3.client('lambda')
+    lambda_client.invoke(
+        FunctionName=context.function_name,
+        InvocationType='Event',
+        Payload=json.dumps(payload)
+    )
+
+    return {
+        'statusCode': 200,
+        'headers': headers,
+        'body': json.dumps({'jobId': job_id, 'status': 'processing'})
+    }
+
+
 def _process_async(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     """
     Perform actual async processing of the file.
@@ -530,23 +643,26 @@ def _process_async(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     analysis_columns = event['analysisColumns']
     input_key = event['inputKey']
     output_key = event['outputKey']
-    
+    phase = event.get('phase', 'full')
+
     try:
-        logger.info(f"Starting async processing for job {job_id}")
-        
-        # Update status to processing
-        _update_job_status(job_id, 'processing', 0, 0)
-        
+        logger.info(f"Starting async processing for job {job_id} (phase={phase})")
+
+        # Update status. Preview phase has its own status so the frontend can poll
+        # and surface the gating UI; full/confirm collapse into the same flow.
+        in_progress_status = 'preview_processing' if phase == 'preview' else 'processing'
+        _update_job_status(job_id, in_progress_status, 0, 0)
+
         # Download input file from S3
         with tempfile.NamedTemporaryFile(delete=False, suffix=f'.{file_type}') as tmp_input:
             input_path = tmp_input.name
             _get_s3_client().download_file(DATA_BUCKET, input_key, input_path)
-        
+
         # Parse input file
         parser = FileParser()
         parsed_file = parser.parse(input_path, file_type)
-        
-        logger.info(f"Processing {parsed_file.row_count} rows")
+
+        logger.info(f"Processing {parsed_file.row_count} rows (phase={phase})")
 
         # Validate selected_comment_column exists in file headers (case-insensitive)
         if selected_comment_column:
@@ -557,35 +673,53 @@ def _process_async(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                     f"file headers {parsed_file.headers}. Will fall back to all columns per row."
                 )
 
-        # Process rows with Bedrock
+        if phase == 'preview':
+            # Slice the parsed file to the first N rows. Reuse the rest of the pipeline.
+            preview_size = min(PREVIEW_ROW_COUNT, parsed_file.row_count)
+            parsed_file.rows = parsed_file.rows[:preview_size]
+            parsed_file.row_count = preview_size
+
+            preview_rows = _process_rows(job_id, parsed_file, analysis_columns,
+                                         selected_comment_column, context_description)
+
+            # Persist preview results to DynamoDB and flip status to preview_ready.
+            # The user will hit POST /process/{jobId}/preview-confirm to continue.
+            _store_preview_rows(job_id, preview_rows, preview_size)
+            _update_job_status(job_id, 'preview_ready', preview_size, preview_size)
+
+            os.unlink(input_path)
+            logger.info(f"Preview completed for job {job_id} ({preview_size} rows)")
+            return {'statusCode': 200, 'body': 'Preview completed'}
+
+        # Full / confirm phase: process all rows
         processed_rows = _process_rows(job_id, parsed_file, analysis_columns,
                                        selected_comment_column, context_description)
-        
+
         # Write output file with error column
         output_headers = parsed_file.headers + [col['name'] for col in analysis_columns] + ['_error']
         with tempfile.NamedTemporaryFile(delete=False, suffix=f'.{file_type}') as tmp_output:
             output_path = tmp_output.name
             writer = FileWriter()
             writer.write(output_headers, processed_rows, output_path, file_type)
-        
+
         # Upload output file to S3
         _get_s3_client().upload_file(output_path, DATA_BUCKET, output_key)
-        
+
         # Update job status to completed with result file key
-        _update_job_status(job_id, 'completed', parsed_file.row_count, parsed_file.row_count, 
+        _update_job_status(job_id, 'completed', parsed_file.row_count, parsed_file.row_count,
                           result_file_key=output_key)
-        
+
         # Clean up temp files
         os.unlink(input_path)
         os.unlink(output_path)
-        
+
         # Trigger aggregate analysis asynchronously so results are pre-computed
         _trigger_aggregate_analysis(job_id)
-        
+
         logger.info(f"Async processing completed for job {job_id}")
-        
+
         return {'statusCode': 200, 'body': 'Processing completed'}
-        
+
     except Exception as e:
         error_message = str(e)
         logger.error(f"Async processing failed for job {job_id}: {error_message}")
@@ -704,7 +838,37 @@ def _get_row_count(s3_key: str, file_type: str) -> int:
         return 0  # Return 0 if we can't determine
 
 
-def _update_job_status(job_id: str, status: str, completed_rows: int, 
+def _store_preview_rows(job_id: str, preview_rows: List[Dict[str, Any]], total_previewed: int) -> None:
+    """Persist preview-phase row results to the job record.
+
+    DynamoDB items are capped at 400 KB; with 20 rows of typical comment data
+    (a few hundred chars of comment + a handful of analysis columns) we land far
+    under that. If a single comment ever exceeds ~15 KB we truncate to keep the
+    item under the limit — the user only needs enough to validate classifications.
+    """
+    MAX_COMMENT_PREVIEW_LEN = 2000
+    sanitized: List[Dict[str, Any]] = []
+    for row in preview_rows:
+        sanitized_row: Dict[str, Any] = {}
+        for k, v in row.items():
+            value = '' if v is None else str(v)
+            if len(value) > MAX_COMMENT_PREVIEW_LEN:
+                value = value[:MAX_COMMENT_PREVIEW_LEN] + '…'
+            sanitized_row[k] = value
+        sanitized.append(sanitized_row)
+
+    table = _get_dynamodb().Table(JOBS_TABLE_NAME)
+    table.update_item(
+        Key={'jobId': job_id},
+        UpdateExpression="SET previewRows = :rows, previewedAt = :ts",
+        ExpressionAttributeValues={
+            ':rows': sanitized,
+            ':ts': datetime.now(timezone.utc).isoformat()
+        }
+    )
+
+
+def _update_job_status(job_id: str, status: str, completed_rows: int,
                       total_rows: int, errors: List[Dict[str, Any]] = None,
                       result_file_key: str = None) -> None:
     """

--- a/backend/row_processor/test_handler.py
+++ b/backend/row_processor/test_handler.py
@@ -15,7 +15,10 @@ from handler import (
     lambda_handler,
     _determine_file_type,
     _update_job_status,
-    _process_single_row
+    _process_single_row,
+    _should_use_preview,
+    PREVIEW_ROW_COUNT,
+    PREVIEW_MIN_FILE_SIZE
 )
 
 
@@ -409,6 +412,197 @@ class TestRowProcessorHandler(unittest.TestCase):
             self.assertIn('Instruction 1', prompt)
             self.assertIn('Instruction 2', prompt)
             self.assertIn('Instruction 3', prompt)
+
+
+class TestInitialProcessRoutesToPreview(unittest.TestCase):
+    """The initial POST /process call should kick off the preview phase when applicable."""
+
+    def setUp(self):
+        os.environ['DATA_BUCKET'] = 'test-bucket'
+        os.environ['JOBS_TABLE'] = 'test-table'
+
+    @patch('boto3.client')
+    @patch('handler._create_job_record_quick')
+    @patch('handler._get_row_count')
+    def test_initial_process_uses_preview_phase_for_categorized_large_file(
+        self, mock_row_count, mock_create_record, mock_boto_client
+    ):
+        mock_row_count.return_value = 200  # large enough for preview
+        mock_lambda = MagicMock()
+        mock_boto_client.return_value = mock_lambda
+
+        ctx = MagicMock()
+        ctx.function_name = 'PublicCommentAnalyzer-RowProcessor-test'
+        event = {
+            'body': json.dumps({
+                'fileId': str(uuid.uuid4()),
+                'selectedCommentColumn': 'comment',
+                'contextDescription': 'Test context',
+                'analysisColumns': [{
+                    'name': 'support',
+                    'type': 'categorized',
+                    'options': [
+                        {'value': 'Support', 'description': 'In favor'},
+                        {'value': 'Oppose', 'description': 'Against'}
+                    ]
+                }]
+            })
+        }
+        response = lambda_handler(event, ctx)
+        self.assertEqual(response['statusCode'], 200)
+
+        invoke_payload = json.loads(mock_lambda.invoke.call_args[1]['Payload'])
+        self.assertEqual(invoke_payload.get('phase'), 'preview')
+
+    @patch('boto3.client')
+    @patch('handler._create_job_record_quick')
+    @patch('handler._get_row_count')
+    def test_initial_process_uses_full_phase_for_open_text_only(
+        self, mock_row_count, mock_create_record, mock_boto_client
+    ):
+        mock_row_count.return_value = 1000
+        mock_lambda = MagicMock()
+        mock_boto_client.return_value = mock_lambda
+
+        ctx = MagicMock()
+        ctx.function_name = 'PublicCommentAnalyzer-RowProcessor-test'
+        event = {
+            'body': json.dumps({
+                'fileId': str(uuid.uuid4()),
+                'selectedCommentColumn': 'comment',
+                'contextDescription': 'Test context',
+                'analysisColumns': [{
+                    'name': 'summary',
+                    'type': 'open_text',
+                    'instructions': 'Summarize.'
+                }]
+            })
+        }
+        response = lambda_handler(event, ctx)
+        self.assertEqual(response['statusCode'], 200)
+
+        invoke_payload = json.loads(mock_lambda.invoke.call_args[1]['Payload'])
+        self.assertEqual(invoke_payload.get('phase'), 'full')
+
+
+class TestPreviewDecision(unittest.TestCase):
+    """The decision rule for whether to run the preview phase."""
+
+    def _categorized_col(self):
+        return {
+            'name': 'support',
+            'type': 'categorized',
+            'options': [
+                {'value': 'Support', 'description': 'In favor'},
+                {'value': 'Oppose', 'description': 'Against'}
+            ]
+        }
+
+    def _open_col(self):
+        return {'name': 'summary', 'type': 'open_text', 'instructions': 'Summarize.'}
+
+    def test_preview_when_categorized_and_file_is_large_enough(self):
+        self.assertTrue(_should_use_preview([self._categorized_col()], total_rows=100))
+
+    def test_no_preview_when_no_categorized_columns(self):
+        self.assertFalse(_should_use_preview([self._open_col()], total_rows=1000))
+
+    def test_no_preview_when_file_smaller_than_threshold(self):
+        # If the user's file is already smaller than PREVIEW_MIN_FILE_SIZE, the preview
+        # would re-process most of the file anyway — just run it normally.
+        self.assertFalse(
+            _should_use_preview([self._categorized_col()], total_rows=PREVIEW_MIN_FILE_SIZE - 1)
+        )
+
+    def test_preview_at_threshold_boundary(self):
+        self.assertTrue(
+            _should_use_preview([self._categorized_col()], total_rows=PREVIEW_MIN_FILE_SIZE)
+        )
+
+
+class TestPreviewConfirmEndpoint(unittest.TestCase):
+    """API contract for POST /process/{jobId}/preview-confirm."""
+
+    def setUp(self):
+        os.environ['DATA_BUCKET'] = 'test-bucket'
+        os.environ['JOBS_TABLE'] = 'test-table'
+
+    def _build_event(self, job_id):
+        return {
+            'pathParameters': {'jobId': job_id},
+            'httpMethod': 'POST',
+            'resource': '/process/{jobId}/preview-confirm',
+            'body': None
+        }
+
+    def test_returns_400_when_path_jobid_is_invalid(self):
+        event = self._build_event('not-a-uuid')
+        response = lambda_handler(event, None)
+        self.assertEqual(response['statusCode'], 400)
+        self.assertEqual(json.loads(response['body'])['error']['code'], 'INVALID_FILE_ID')
+
+    @patch('handler._get_dynamodb')
+    def test_returns_404_when_job_does_not_exist(self, mock_dynamo):
+        # DynamoDB returns no Item
+        mock_table = MagicMock()
+        mock_table.get_item.return_value = {}
+        mock_dynamo.return_value.Table.return_value = mock_table
+
+        event = self._build_event(str(uuid.uuid4()))
+        response = lambda_handler(event, None)
+        self.assertEqual(response['statusCode'], 404)
+        self.assertEqual(json.loads(response['body'])['error']['code'], 'JOB_NOT_FOUND')
+
+    @patch('handler._get_dynamodb')
+    def test_returns_409_when_job_is_not_in_preview_ready_state(self, mock_dynamo):
+        mock_table = MagicMock()
+        mock_table.get_item.return_value = {
+            'Item': {'jobId': 'abc', 'status': 'completed'}
+        }
+        mock_dynamo.return_value.Table.return_value = mock_table
+
+        event = self._build_event(str(uuid.uuid4()))
+        response = lambda_handler(event, None)
+        self.assertEqual(response['statusCode'], 409)
+        self.assertEqual(json.loads(response['body'])['error']['code'], 'INVALID_JOB_STATE')
+
+    @patch('boto3.client')
+    @patch('handler._get_dynamodb')
+    def test_invokes_row_processor_async_with_confirm_phase(self, mock_dynamo, mock_boto_client):
+        job_id = str(uuid.uuid4())
+        mock_table = MagicMock()
+        mock_table.get_item.return_value = {
+            'Item': {
+                'jobId': job_id,
+                'status': 'preview_ready',
+                'fileId': 'fid',
+                'fileType': 'csv',
+                'inputFileKey': f'uploads/fid/input.csv',
+                'outputFileKey': f'results/{job_id}/output.csv',
+                'analysisColumns': [{'name': 'support', 'type': 'categorized',
+                                     'options': [{'value': 'Support', 'description': 'In favor'},
+                                                 {'value': 'Oppose', 'description': 'Against'}]}],
+                'selectedCommentColumn': 'comment',
+                'contextDescription': 'Test context'
+            }
+        }
+        mock_dynamo.return_value.Table.return_value = mock_table
+        mock_lambda = MagicMock()
+        mock_boto_client.return_value = mock_lambda
+
+        ctx = MagicMock()
+        ctx.function_name = 'PublicCommentAnalyzer-RowProcessor-test'
+        event = self._build_event(job_id)
+        response = lambda_handler(event, ctx)
+
+        self.assertEqual(response['statusCode'], 200)
+        # Must have invoked self async with phase=confirm
+        invoke_call = mock_lambda.invoke.call_args
+        self.assertEqual(invoke_call[1]['InvocationType'], 'Event')
+        payload = json.loads(invoke_call[1]['Payload'])
+        self.assertTrue(payload.get('asyncProcessing'))
+        self.assertEqual(payload.get('phase'), 'confirm')
+        self.assertEqual(payload.get('jobId'), job_id)
 
 
 if __name__ == '__main__':

--- a/backend/row_processor/test_handler.py
+++ b/backend/row_processor/test_handler.py
@@ -178,6 +178,204 @@ class TestRowProcessorHandler(unittest.TestCase):
         
         self.assertEqual(mock_bedrock.invoke_model.call_count, 3)
     
+    @patch('handler._get_bedrock_runtime')
+    def test_categorized_column_uses_temperature_zero(self, mock_get_bedrock):
+        """When any categorized column is present, Bedrock is called with temperature=0 for determinism."""
+        mock_bedrock = MagicMock()
+        mock_get_bedrock.return_value = mock_bedrock
+        mock_bedrock.invoke_model.return_value = {
+            'body': MagicMock(read=MagicMock(return_value=json.dumps({
+                'content': [{'text': json.dumps({'support': 'Support'})}]
+            }).encode('utf-8')))
+        }
+
+        row = {'comment': 'Legalize it'}
+        analysis_columns = [{
+            'name': 'support',
+            'type': 'categorized',
+            'options': [
+                {'value': 'Support', 'description': 'In favor'},
+                {'value': 'Oppose', 'description': 'Against'}
+            ]
+        }]
+
+        _process_single_row(row, analysis_columns)
+
+        body = json.loads(mock_bedrock.invoke_model.call_args[1]['body'])
+        self.assertEqual(body.get('temperature'), 0,
+                         f"Expected temperature=0 for categorized columns, got body={body}")
+
+    @patch('handler._get_bedrock_runtime')
+    def test_open_text_only_does_not_force_temperature(self, mock_get_bedrock):
+        """Open-text-only runs leave temperature unset so Bedrock uses its default."""
+        mock_bedrock = MagicMock()
+        mock_get_bedrock.return_value = mock_bedrock
+        mock_bedrock.invoke_model.return_value = {
+            'body': MagicMock(read=MagicMock(return_value=json.dumps({
+                'content': [{'text': json.dumps({'summary': 'A summary.'})}]
+            }).encode('utf-8')))
+        }
+
+        row = {'comment': 'Some comment text'}
+        analysis_columns = [{'name': 'summary', 'instructions': 'One sentence.'}]
+
+        _process_single_row(row, analysis_columns)
+
+        body = json.loads(mock_bedrock.invoke_model.call_args[1]['body'])
+        self.assertNotIn('temperature', body,
+                         "Open-text-only runs should not set temperature explicitly")
+
+    @patch('handler._get_bedrock_runtime')
+    def test_retry_call_uses_temperature_zero(self, mock_get_bedrock):
+        """Categorized retry calls always use temperature=0."""
+        mock_bedrock = MagicMock()
+        mock_get_bedrock.return_value = mock_bedrock
+
+        # First call returns an unmatched value to trigger retry path; retry returns valid value
+        mock_bedrock.invoke_model.side_effect = [
+            {
+                'body': MagicMock(read=MagicMock(return_value=json.dumps({
+                    'content': [{'text': json.dumps({'support': 'banana'})}]
+                }).encode('utf-8')))
+            },
+            {
+                'body': MagicMock(read=MagicMock(return_value=json.dumps({
+                    'content': [{'text': 'Support'}]
+                }).encode('utf-8')))
+            }
+        ]
+
+        row = {'comment': 'I support this'}
+        analysis_columns = [{
+            'name': 'support',
+            'type': 'categorized',
+            'options': [
+                {'value': 'Support', 'description': 'In favor'},
+                {'value': 'Oppose', 'description': 'Against'}
+            ]
+        }]
+
+        _process_single_row(row, analysis_columns)
+
+        # Verify both calls used temperature=0
+        self.assertGreaterEqual(mock_bedrock.invoke_model.call_count, 2)
+        for call in mock_bedrock.invoke_model.call_args_list:
+            body = json.loads(call[1]['body'])
+            self.assertEqual(body.get('temperature'), 0,
+                             f"All categorized + retry calls should use temperature=0, got body={body}")
+
+    @patch('handler._get_bedrock_runtime')
+    def test_examples_are_rendered_into_prompt(self, mock_get_bedrock):
+        """Few-shot examples on a categorized column appear in the prompt as an <examples> block."""
+        mock_bedrock = MagicMock()
+        mock_get_bedrock.return_value = mock_bedrock
+        mock_bedrock.invoke_model.return_value = {
+            'body': MagicMock(read=MagicMock(return_value=json.dumps({
+                'content': [{'text': json.dumps({'support': 'Support'})}]
+            }).encode('utf-8')))
+        }
+
+        row = {'comment': 'I support legalization'}
+        analysis_columns = [{
+            'name': 'support',
+            'type': 'categorized',
+            'options': [
+                {'value': 'Support', 'description': 'In favor'},
+                {'value': 'Oppose', 'description': 'Against'}
+            ],
+            'examples': [
+                {'commentText': 'Legalize cannabis now!', 'label': 'Support'},
+                {'commentText': 'Cannabis should remain illegal.', 'label': 'Oppose'}
+            ]
+        }]
+
+        _process_single_row(row, analysis_columns)
+
+        prompt = json.loads(mock_bedrock.invoke_model.call_args[1]['body'])['messages'][0]['content']
+        self.assertIn('<examples>', prompt, f"Expected <examples> block in prompt:\n{prompt}")
+        self.assertIn('</examples>', prompt)
+        self.assertIn('Legalize cannabis now!', prompt)
+        self.assertIn('Cannabis should remain illegal.', prompt)
+        # Each example should pair the comment text with its expected label
+        self.assertIn('Support', prompt)
+        self.assertIn('Oppose', prompt)
+
+    @patch('handler._get_bedrock_runtime')
+    def test_no_examples_omits_examples_block(self, mock_get_bedrock):
+        """When no examples are supplied, the prompt does not contain an <examples> block."""
+        mock_bedrock = MagicMock()
+        mock_get_bedrock.return_value = mock_bedrock
+        mock_bedrock.invoke_model.return_value = {
+            'body': MagicMock(read=MagicMock(return_value=json.dumps({
+                'content': [{'text': json.dumps({'support': 'Support'})}]
+            }).encode('utf-8')))
+        }
+
+        row = {'comment': 'Test'}
+        analysis_columns = [{
+            'name': 'support',
+            'type': 'categorized',
+            'options': [
+                {'value': 'Support', 'description': 'In favor'},
+                {'value': 'Oppose', 'description': 'Against'}
+            ]
+        }]
+
+        _process_single_row(row, analysis_columns)
+
+        prompt = json.loads(mock_bedrock.invoke_model.call_args[1]['body'])['messages'][0]['content']
+        self.assertNotIn('<examples>', prompt)
+
+    def test_invalid_example_missing_label_returns_400(self):
+        """An example missing a label is rejected at the API layer."""
+        event = {
+            'body': json.dumps({
+                'fileId': str(uuid.uuid4()),
+                'selectedCommentColumn': 'comment',
+                'contextDescription': 'Test context',
+                'analysisColumns': [{
+                    'name': 'support',
+                    'type': 'categorized',
+                    'options': [
+                        {'value': 'Support', 'description': 'In favor'},
+                        {'value': 'Oppose', 'description': 'Against'}
+                    ],
+                    'examples': [
+                        {'commentText': 'A comment without a label'}
+                    ]
+                }]
+            })
+        }
+        response = lambda_handler(event, None)
+        self.assertEqual(response['statusCode'], 400)
+        body = json.loads(response['body'])
+        self.assertEqual(body['error']['code'], 'INVALID_EXAMPLE')
+
+    def test_too_many_examples_returns_400(self):
+        """More than 5 examples per column is rejected."""
+        event = {
+            'body': json.dumps({
+                'fileId': str(uuid.uuid4()),
+                'selectedCommentColumn': 'comment',
+                'contextDescription': 'Test context',
+                'analysisColumns': [{
+                    'name': 'support',
+                    'type': 'categorized',
+                    'options': [
+                        {'value': 'Support', 'description': 'In favor'},
+                        {'value': 'Oppose', 'description': 'Against'}
+                    ],
+                    'examples': [
+                        {'commentText': f'Example {i}', 'label': 'Support'} for i in range(6)
+                    ]
+                }]
+            })
+        }
+        response = lambda_handler(event, None)
+        self.assertEqual(response['statusCode'], 400)
+        body = json.loads(response['body'])
+        self.assertEqual(body['error']['code'], 'TOO_MANY_EXAMPLES')
+
     def test_prompt_includes_all_columns(self):
         """Test that prompt includes all analysis column instructions."""
         with patch('handler._get_bedrock_runtime') as mock_get_bedrock:

--- a/backend/status_handler/handler.py
+++ b/backend/status_handler/handler.py
@@ -54,17 +54,24 @@ def lambda_handler(event, context):
                 'body': json.dumps({'error': {'code': 'JOB_NOT_FOUND', 'message': 'Job not found'}})
             }
         item = response['Item']
+        body = {
+            'jobId': item.get('jobId'),
+            'status': item.get('status'),
+            'progress': round((item.get('completedRows', 0) / item.get('totalRows', 1)) * 100, 2) if item.get('totalRows') else 0,
+            'completedRows': item.get('completedRows', 0),
+            'totalRows': item.get('totalRows', 0),
+            'errors': item.get('errors', [])
+        }
+        # Surface preview rows + the analysis column definitions so the frontend
+        # can render the preview table while gating on user confirmation.
+        if item.get('status') == 'preview_ready' and item.get('previewRows'):
+            body['previewRows'] = item['previewRows']
+            body['analysisColumns'] = item.get('analysisColumns', [])
+            body['selectedCommentColumn'] = item.get('selectedCommentColumn')
         return {
             'statusCode': 200,
             'headers': {'Content-Type': 'application/json', 'Access-Control-Allow-Origin': CORS_ORIGIN},
-            'body': json.dumps({
-                'jobId': item.get('jobId'),
-                'status': item.get('status'),
-                'progress': round((item.get('completedRows', 0) / item.get('totalRows', 1)) * 100, 2) if item.get('totalRows') else 0,
-                'completedRows': item.get('completedRows', 0),
-                'totalRows': item.get('totalRows', 0),
-                'errors': item.get('errors', [])
-            }, default=decimal_default)
+            'body': json.dumps(body, default=decimal_default)
         }
     except Exception as e:
         logger.error(f"Status handler error: {str(e)}")

--- a/backend/status_handler/test_handler.py
+++ b/backend/status_handler/test_handler.py
@@ -1,0 +1,93 @@
+"""Unit tests for status handler Lambda."""
+
+import json
+import os
+import sys
+import unittest
+import uuid
+from unittest.mock import MagicMock, patch
+
+os.environ['JOBS_TABLE'] = 'test-jobs-table'
+os.environ['ALLOWED_ORIGIN'] = '*'
+
+# Auth shim is loaded from sys.path side-load; bypass auth for tests.
+sys.path.insert(0, os.path.dirname(__file__))
+
+
+def _build_event(job_id):
+    return {
+        'pathParameters': {'jobId': job_id},
+        'headers': {'X-Access-Key': 'irrelevant-bypassed'},
+    }
+
+
+class TestStatusHandler(unittest.TestCase):
+
+    def setUp(self):
+        # Re-import handler under fresh patch so we can swap out the table object.
+        import importlib
+        if 'handler' in sys.modules:
+            del sys.modules['handler']
+        with patch('boto3.resource'):
+            import handler  # type: ignore
+            self.handler = handler
+
+    def _patch_auth_to_pass(self):
+        return patch.object(self.handler, 'validate_access_key', return_value=True)
+
+    def test_returns_400_for_invalid_uuid(self):
+        with self._patch_auth_to_pass():
+            response = self.handler.lambda_handler(_build_event('not-a-uuid'), None)
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_includes_preview_rows_when_status_is_preview_ready(self):
+        job_id = str(uuid.uuid4())
+        mock_table = MagicMock()
+        mock_table.get_item.return_value = {
+            'Item': {
+                'jobId': job_id,
+                'status': 'preview_ready',
+                'completedRows': 20,
+                'totalRows': 100,
+                'errors': [],
+                'previewRows': [
+                    {'comment': 'I support legalization', 'support': 'Support', '_error': ''},
+                    {'comment': 'Cannabis should remain illegal', 'support': 'Oppose', '_error': ''}
+                ]
+            }
+        }
+        self.handler.table = mock_table
+
+        with self._patch_auth_to_pass():
+            response = self.handler.lambda_handler(_build_event(job_id), None)
+
+        self.assertEqual(response['statusCode'], 200)
+        body = json.loads(response['body'])
+        self.assertEqual(body['status'], 'preview_ready')
+        self.assertIn('previewRows', body)
+        self.assertEqual(len(body['previewRows']), 2)
+        self.assertEqual(body['previewRows'][0]['support'], 'Support')
+
+    def test_omits_preview_rows_when_status_is_completed(self):
+        job_id = str(uuid.uuid4())
+        mock_table = MagicMock()
+        mock_table.get_item.return_value = {
+            'Item': {
+                'jobId': job_id,
+                'status': 'completed',
+                'completedRows': 100,
+                'totalRows': 100,
+                'errors': []
+            }
+        }
+        self.handler.table = mock_table
+
+        with self._patch_auth_to_pass():
+            response = self.handler.lambda_handler(_build_event(job_id), None)
+
+        body = json.loads(response['body'])
+        self.assertNotIn('previewRows', body)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/frontend/.husky/pre-push
+++ b/frontend/.husky/pre-push
@@ -15,7 +15,7 @@ fi
 
 FAILED=0
 
-for lambda_dir in shared upload_handler row_processor aggregate_analyzer; do
+for lambda_dir in shared upload_handler row_processor aggregate_analyzer status_handler; do
     dir="backend/$lambda_dir"
     if ls "$dir"/test_*.py 1>/dev/null 2>&1; then
         echo "▶ Testing backend/$lambda_dir..."

--- a/frontend/src/app/components/column-definition/column-definition.component.html
+++ b/frontend/src/app/components/column-definition/column-definition.component.html
@@ -53,26 +53,72 @@
             <div formArrayName="options">
               <div *ngFor="let option of optionsArray.controls; let i = index"
                    [formGroupName]="i"
-                   class="option-row">
-                <mat-form-field appearance="outline" class="option-value">
-                  <mat-label>Option {{ i + 1 }}</mat-label>
-                  <input matInput formControlName="value" placeholder="e.g., Pro">
-                </mat-form-field>
-                <mat-form-field appearance="outline" class="option-description">
-                  <mat-label>When to choose this</mat-label>
-                  <input matInput formControlName="description" placeholder="e.g., If the comment supports the proposal">
-                </mat-form-field>
-                <button mat-icon-button type="button" (click)="removeOption(i)"
-                        [disabled]="optionsArray.length <= 2"
-                        aria-label="Remove option">
-                  <mat-icon>close</mat-icon>
-                </button>
+                   class="option-row-wrapper">
+                <div class="option-row">
+                  <mat-form-field appearance="outline" class="option-value">
+                    <mat-label>Option {{ i + 1 }}</mat-label>
+                    <input matInput formControlName="value" placeholder="e.g., Pro">
+                  </mat-form-field>
+                  <mat-form-field appearance="outline" class="option-description">
+                    <mat-label>When to choose this</mat-label>
+                    <input matInput formControlName="description" placeholder="e.g., If the comment supports the proposal">
+                  </mat-form-field>
+                  <button mat-icon-button type="button" (click)="removeOption(i)"
+                          [disabled]="optionsArray.length <= 2"
+                          aria-label="Remove option">
+                    <mat-icon>close</mat-icon>
+                  </button>
+                </div>
+                <div class="option-warning"
+                     *ngFor="let warning of getDescriptionWarnings(option.get('description')?.value || '')"
+                     role="alert">
+                  <mat-icon class="warning-icon" aria-hidden="true">warning</mat-icon>
+                  <span>{{ warning }}</span>
+                </div>
               </div>
             </div>
             <button mat-stroked-button type="button" (click)="addOption()"
                     [disabled]="optionsArray.length >= 50"
                     class="add-option-btn">
               <mat-icon>add</mat-icon> Add Option
+            </button>
+            <div class="structure-warning" *ngIf="getCategoryStructureWarning() as structWarning" role="alert">
+              <mat-icon class="warning-icon" aria-hidden="true">warning</mat-icon>
+              <span>{{ structWarning }}</span>
+            </div>
+          </div>
+
+          <div class="examples-section">
+            <p class="options-hint">
+              Optional: add up to 5 example comments with the correct label. Few-shot examples are the single largest accuracy lever for nuanced taxonomies.
+            </p>
+            <div formArrayName="examples">
+              <div *ngFor="let example of examplesArray.controls; let ei = index"
+                   [formGroupName]="ei"
+                   class="example-row">
+                <mat-form-field appearance="outline" class="example-comment">
+                  <mat-label>Example comment</mat-label>
+                  <textarea matInput rows="2" formControlName="commentText"
+                            placeholder="A representative comment for this label"></textarea>
+                </mat-form-field>
+                <mat-form-field appearance="outline" class="example-label">
+                  <mat-label>Label</mat-label>
+                  <input matInput formControlName="label" [attr.list]="'example-labels-' + ei"
+                         placeholder="Option value">
+                </mat-form-field>
+                <datalist [attr.id]="'example-labels-' + ei">
+                  <option *ngFor="let opt of optionsArray.controls" [value]="opt.get('value')?.value"></option>
+                </datalist>
+                <button mat-icon-button type="button" (click)="removeExample(ei)"
+                        aria-label="Remove example">
+                  <mat-icon>close</mat-icon>
+                </button>
+              </div>
+            </div>
+            <button mat-stroked-button type="button" (click)="addExample()"
+                    [disabled]="examplesArray.length >= 5"
+                    class="add-example-btn">
+              <mat-icon>add</mat-icon> Add Example
             </button>
           </div>
         </ng-container>

--- a/frontend/src/app/components/column-definition/column-definition.component.scss
+++ b/frontend/src/app/components/column-definition/column-definition.component.scss
@@ -60,6 +60,63 @@
     .add-option-btn {
       margin-top: $spacing-sm;
     }
+
+    .option-row-wrapper {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .option-warning,
+    .structure-warning {
+      display: flex;
+      align-items: flex-start;
+      gap: $spacing-xs;
+      padding: $spacing-xs $spacing-sm;
+      margin-top: $spacing-xs;
+      background-color: color.adjust(#b58105, $lightness: 55%);
+      border-left: 3px solid #b58105;
+      border-radius: $border-radius;
+      color: color.adjust(#b58105, $lightness: -10%);
+      font-size: $font-size-breadcrumb;
+      line-height: 1.4;
+
+      .warning-icon {
+        font-size: 18px;
+        width: 18px;
+        height: 18px;
+        flex-shrink: 0;
+        margin-top: 1px;
+      }
+    }
+
+    .structure-warning {
+      margin-top: $spacing-md;
+    }
+  }
+
+  .examples-section {
+    margin-top: $spacing-lg;
+    padding-top: $spacing-md;
+    border-top: 1px solid $color-gray;
+
+    .example-row {
+      display: flex;
+      align-items: flex-start;
+      gap: $spacing-sm;
+      margin-bottom: $spacing-xs;
+
+      .example-comment {
+        flex: 3;
+      }
+
+      .example-label {
+        flex: 1;
+      }
+    }
+
+    .add-example-btn {
+      margin-top: $spacing-sm;
+    }
   }
 
   .button-group {

--- a/frontend/src/app/components/column-definition/column-definition.component.spec.ts
+++ b/frontend/src/app/components/column-definition/column-definition.component.spec.ts
@@ -204,6 +204,116 @@ describe('ColumnDefinitionComponent', () => {
       }
       expect(component.optionsArray.length).toBeLessThanOrEqual(50);
     });
+
+    it('starts with zero examples', () => {
+      expect(component.examplesArray.length).toBe(0);
+    });
+
+    it('addExample adds an example with empty commentText and label', () => {
+      component.addExample();
+      expect(component.examplesArray.length).toBe(1);
+      expect(component.examplesArray.at(0).get('commentText')?.value).toBe('');
+      expect(component.examplesArray.at(0).get('label')?.value).toBe('');
+    });
+
+    it('removeExample removes the example at the given index', () => {
+      component.addExample();
+      component.addExample();
+      component.removeExample(0);
+      expect(component.examplesArray.length).toBe(1);
+    });
+
+    it('caps examples at 5 per column', () => {
+      for (let i = 0; i < 10; i++) {
+        component.addExample();
+      }
+      expect(component.examplesArray.length).toBe(5);
+    });
+
+    it('persists examples on the saved categorized column', () => {
+      component.columnForm.patchValue({ name: 'Stance' });
+      component.optionsArray.at(0).patchValue({ value: 'Pro', description: 'Supports' });
+      component.optionsArray.at(1).patchValue({ value: 'Against', description: 'Opposes' });
+      component.addExample();
+      component.examplesArray.at(0).patchValue({
+        commentText: 'I love this proposal.',
+        label: 'Pro'
+      });
+
+      component.addColumn();
+
+      expect(component.columns.length).toBe(1);
+      expect(component.columns[0].examples?.length).toBe(1);
+      expect(component.columns[0].examples?.[0].commentText).toBe('I love this proposal.');
+      expect(component.columns[0].examples?.[0].label).toBe('Pro');
+    });
+
+    it('blocks save when an example has commentText but no label', () => {
+      component.columnForm.patchValue({ name: 'Stance' });
+      component.optionsArray.at(0).patchValue({ value: 'Pro', description: 'Supports' });
+      component.optionsArray.at(1).patchValue({ value: 'Against', description: 'Opposes' });
+      component.addExample();
+      component.examplesArray.at(0).patchValue({
+        commentText: 'Has text but no label',
+        label: ''
+      });
+
+      component.addColumn();
+
+      expect(component.columns.length).toBe(0);
+      expect(component.errorMessage).toBeTruthy();
+    });
+
+    it('drops fully-empty example rows on save (so users can leave a blank slot)', () => {
+      component.columnForm.patchValue({ name: 'Stance' });
+      component.optionsArray.at(0).patchValue({ value: 'Pro', description: 'Supports' });
+      component.optionsArray.at(1).patchValue({ value: 'Against', description: 'Opposes' });
+      component.addExample();
+      // Leave both fields empty
+
+      component.addColumn();
+
+      expect(component.columns.length).toBe(1);
+      expect(component.columns[0].examples?.length || 0).toBe(0);
+    });
+
+    it('renders an Add Example button only when column type is categorized', () => {
+      // Already in categorized mode via outer describe's beforeEach
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      const addExampleBtn = compiled.querySelector('.add-example-btn');
+      expect(addExampleBtn).toBeTruthy();
+    });
+
+    it('renders example rows after addExample is called', () => {
+      component.addExample();
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      const exampleRows = compiled.querySelectorAll('.example-row');
+      expect(exampleRows.length).toBe(1);
+    });
+
+    it('repopulates examples when editing a categorized column', () => {
+      component.columns = [{
+        name: 'Stance',
+        instructions: 'Pro: Supports; Against: Opposes',
+        type: 'categorized',
+        options: [
+          { value: 'Pro', description: 'Supports' },
+          { value: 'Against', description: 'Opposes' }
+        ],
+        examples: [
+          { commentText: 'Yes please', label: 'Pro' },
+          { commentText: 'No way', label: 'Against' }
+        ]
+      }];
+
+      component.editColumn(0);
+
+      expect(component.examplesArray.length).toBe(2);
+      expect(component.examplesArray.at(0).get('commentText')?.value).toBe('Yes please');
+      expect(component.examplesArray.at(0).get('label')?.value).toBe('Pro');
+    });
   });
 
   describe('Column Type Toggle', () => {
@@ -313,6 +423,89 @@ describe('ColumnDefinitionComponent', () => {
 
       expect(component.editingIndex).toBeNull();
       expect(component.columnForm.get('name')?.value).toBeNull();
+    });
+  });
+
+  describe('Description Lint Warnings', () => {
+    beforeEach(() => {
+      component.onColumnTypeChange('categorized');
+    });
+
+    it('flags a description containing the poison word "default"', () => {
+      const warnings = component.getDescriptionWarnings(
+        'This is the default for comments that say "Legalize it".'
+      );
+      expect(warnings.some(w => w.toLowerCase().includes('default'))).toBeTruthy();
+    });
+
+    it('flags a description containing the poison word "usually"', () => {
+      const warnings = component.getDescriptionWarnings(
+        'They usually oppose recreational use.'
+      );
+      expect(warnings.some(w => w.toLowerCase().includes('usually'))).toBeTruthy();
+    });
+
+    it('flags a description containing the poison phrase "most likely"', () => {
+      const warnings = component.getDescriptionWarnings(
+        'Pick this when the comment is most likely about cannabis.'
+      );
+      expect(warnings.some(w => w.toLowerCase().includes('most likely'))).toBeTruthy();
+    });
+
+    it('does not flag a clean description', () => {
+      const warnings = component.getDescriptionWarnings(
+        'The commenter supports broad medical access for chronic conditions.'
+      );
+      expect(warnings.length).toBe(0);
+    });
+
+    it('matches poison words case-insensitively but only as whole words', () => {
+      // "Defaulted" should NOT match "default" — substring matching would over-trigger
+      const warnings = component.getDescriptionWarnings('They defaulted on payment.');
+      expect(warnings.length).toBe(0);
+    });
+
+    it('warns when categorized column has more than 5 options without examples', () => {
+      // Add 4 more options so we have 6 total
+      for (let i = 0; i < 4; i++) {
+        component.addOption();
+      }
+      expect(component.optionsArray.length).toBe(6);
+      expect(component.getCategoryStructureWarning()).toContain('5');
+    });
+
+    it('does not warn when categorized column has 5 or fewer options', () => {
+      // Default is 2 options — add 3 more for 5 total
+      for (let i = 0; i < 3; i++) {
+        component.addOption();
+      }
+      expect(component.optionsArray.length).toBe(5);
+      expect(component.getCategoryStructureWarning()).toBeNull();
+    });
+
+    it('renders the description warning in the UI when a poison word is typed', () => {
+      component.optionsArray.at(0).patchValue({
+        value: '6',
+        description: 'This is the default for legalize-it comments.'
+      });
+      fixture.detectChanges();
+
+      const compiled = fixture.nativeElement as HTMLElement;
+      const warningEl = compiled.querySelector('.option-warning');
+      expect(warningEl).toBeTruthy();
+      expect(warningEl?.textContent?.toLowerCase()).toContain('default');
+    });
+
+    it('renders the structure warning in the UI when more than 5 options exist', () => {
+      for (let i = 0; i < 4; i++) {
+        component.addOption();
+      }
+      fixture.detectChanges();
+
+      const compiled = fixture.nativeElement as HTMLElement;
+      const structureWarning = compiled.querySelector('.structure-warning');
+      expect(structureWarning).toBeTruthy();
+      expect(structureWarning?.textContent).toContain('5');
     });
   });
 

--- a/frontend/src/app/components/column-definition/column-definition.component.ts
+++ b/frontend/src/app/components/column-definition/column-definition.component.ts
@@ -9,7 +9,7 @@ import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
-import { AnalysisColumn, CategoryOption, ProcessingService } from '../../services/processing.service';
+import { AnalysisColumn, CategoryExample, CategoryOption, ProcessingService } from '../../services/processing.service';
 import { FileMetadata } from '../../services/file-upload.service';
 
 @Component({
@@ -51,7 +51,8 @@ export class ColumnDefinitionComponent implements OnInit {
     this.columnForm = this.fb.group({
       name: [''],
       instructions: [''],
-      options: this.fb.array([])
+      options: this.fb.array([]),
+      examples: this.fb.array([])
     });
 
     // Get file metadata from navigation state
@@ -87,6 +88,24 @@ export class ColumnDefinitionComponent implements OnInit {
 
   get optionsArray(): FormArray {
     return this.columnForm.get('options') as FormArray;
+  }
+
+  get examplesArray(): FormArray {
+    return this.columnForm.get('examples') as FormArray;
+  }
+
+  static readonly MAX_EXAMPLES = 5;
+
+  addExample(): void {
+    if (this.examplesArray.length >= ColumnDefinitionComponent.MAX_EXAMPLES) return;
+    this.examplesArray.push(this.fb.group({
+      commentText: [''],
+      label: ['']
+    }));
+  }
+
+  removeExample(index: number): void {
+    this.examplesArray.removeAt(index);
   }
 
   onColumnTypeChange(type: 'open_text' | 'categorized'): void {
@@ -166,6 +185,25 @@ export class ColumnDefinitionComponent implements OnInit {
         return;
       }
 
+      // Validate optional examples: drop fully-empty rows; reject partial rows.
+      const rawExamples = this.columnForm.value.examples || [];
+      const validOptionValues = new Set(options.map(o => o.value));
+      const examples: CategoryExample[] = [];
+      for (const ex of rawExamples) {
+        const commentText = (ex.commentText || '').trim();
+        const label = (ex.label || '').trim();
+        if (!commentText && !label) continue; // empty row, skip
+        if (!commentText || !label) {
+          this.errorMessage = 'Each example needs both comment text and a label, or leave both blank to remove it.';
+          return;
+        }
+        if (!validOptionValues.has(label)) {
+          this.errorMessage = `Example label "${label}" must match one of the option values.`;
+          return;
+        }
+        examples.push({ commentText, label });
+      }
+
       // Build instructions string from options for backend compatibility
       const instructions = options.map(o => `${o.value}: ${o.description}`).join('; ');
 
@@ -173,7 +211,8 @@ export class ColumnDefinitionComponent implements OnInit {
         name,
         instructions,
         type: 'categorized',
-        options
+        options,
+        ...(examples.length > 0 ? { examples } : {})
       };
 
       if (this.editingIndex !== null) {
@@ -195,15 +234,21 @@ export class ColumnDefinitionComponent implements OnInit {
     while (this.optionsArray.length > 0) {
       this.optionsArray.removeAt(0);
     }
+    while (this.examplesArray.length > 0) {
+      this.examplesArray.removeAt(0);
+    }
   }
 
   editColumn(index: number): void {
     const column = this.columns[index];
     this.columnType = column.type || 'open_text';
 
-    // Clear existing options
+    // Clear existing options + examples
     while (this.optionsArray.length > 0) {
       this.optionsArray.removeAt(0);
+    }
+    while (this.examplesArray.length > 0) {
+      this.examplesArray.removeAt(0);
     }
 
     if (this.columnType === 'categorized' && column.options) {
@@ -211,6 +256,12 @@ export class ColumnDefinitionComponent implements OnInit {
         this.optionsArray.push(this.fb.group({
           value: [opt.value],
           description: [opt.description]
+        }));
+      }
+      for (const ex of column.examples || []) {
+        this.examplesArray.push(this.fb.group({
+          commentText: [ex.commentText],
+          label: [ex.label]
         }));
       }
       this.columnForm.patchValue({ name: column.name, instructions: '' });
@@ -241,6 +292,31 @@ export class ColumnDefinitionComponent implements OnInit {
 
   get isEditing(): boolean {
     return this.editingIndex !== null;
+  }
+
+  // Words/phrases in option descriptions that bias the classifier (e.g., bucket 6's
+  // "This is the default for…" wording caused 67% of cannabis comments to land in 6).
+  // Matched as whole-word, case-insensitive.
+  private static readonly POISON_PATTERNS: Array<{label: string; regex: RegExp}> = [
+    { label: 'default', regex: /\bdefault\b/i },
+    { label: 'usually', regex: /\busually\b/i },
+    { label: 'most likely', regex: /\bmost likely\b/i },
+    { label: 'the answer', regex: /\bthe answer\b/i },
+    { label: 'obviously', regex: /\bobviously\b/i }
+  ];
+
+  getDescriptionWarnings(description: string): string[] {
+    if (!description) return [];
+    return ColumnDefinitionComponent.POISON_PATTERNS
+      .filter(p => p.regex.test(description))
+      .map(p => `Avoid the word "${p.label}" — it biases the AI toward this option when it's uncertain.`);
+  }
+
+  getCategoryStructureWarning(): string | null {
+    if (this.optionsArray.length > 5) {
+      return 'Categorized columns with more than 5 options are harder for the AI to distinguish reliably. Consider consolidating, or add 1-2 example comments per option.';
+    }
+    return null;
   }
 
   startProcessing(): void {

--- a/frontend/src/app/components/processing-monitor/processing-monitor.component.html
+++ b/frontend/src/app/components/processing-monitor/processing-monitor.component.html
@@ -26,7 +26,7 @@
 
         <!-- Processing -->
         <ng-container *ngIf="currentStep === 1">
-          <mat-icon class="step-icon" *ngIf="!hasFailed">sync</mat-icon>
+          <mat-icon class="step-icon spinning" *ngIf="!hasFailed">sync</mat-icon>
           <mat-icon class="step-icon error" *ngIf="hasFailed">error</mat-icon>
           <p>{{ statusMessage }}</p>
 

--- a/frontend/src/app/components/processing-monitor/processing-monitor.component.html
+++ b/frontend/src/app/components/processing-monitor/processing-monitor.component.html
@@ -46,8 +46,59 @@
           </div>
         </ng-container>
 
+        <!-- Preview ready: show sample classifications + confirm/cancel -->
+        <ng-container *ngIf="jobStatus?.status === 'preview_ready' && !hasFailed">
+          <mat-icon class="step-icon">preview</mat-icon>
+          <p>{{ statusMessage }}</p>
+
+          <div class="preview-section">
+            <p class="preview-hint">
+              Below are <strong>{{ jobStatus?.previewRows?.length }}</strong> sample classifications from your file.
+              If they look reasonable, confirm to process the remaining
+              <strong>{{ (jobStatus?.totalRows || 0) - (jobStatus?.completedRows || 0) }}</strong> rows.
+              If they look wrong, cancel and revise your column definitions.
+            </p>
+
+            <div class="preview-table-wrapper">
+              <table class="preview-table" *ngIf="jobStatus?.previewRows?.length">
+                <thead>
+                  <tr>
+                    <th>{{ previewCommentColumn }}</th>
+                    <th *ngFor="let colName of previewColumnNames">{{ colName }}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr *ngFor="let row of jobStatus?.previewRows">
+                    <td class="preview-comment-cell">{{ row[previewCommentColumn] || '(empty)' }}</td>
+                    <td *ngFor="let colName of previewColumnNames">{{ row[colName] }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="preview-error" *ngIf="previewError" role="alert">
+              <mat-icon>error</mat-icon>
+              <span>{{ previewError }}</span>
+            </div>
+
+            <div class="preview-actions">
+              <button mat-raised-button color="primary"
+                      class="confirm-preview-btn"
+                      (click)="confirmPreview()"
+                      [disabled]="isConfirmingPreview">
+                <mat-icon>play_arrow</mat-icon>
+                {{ isConfirmingPreview ? 'Starting full run...' : 'Looks right — process all rows' }}
+              </button>
+              <button mat-button routerLink="/upload" [disabled]="isConfirmingPreview">
+                <mat-icon>arrow_back</mat-icon>
+                Cancel and revise
+              </button>
+            </div>
+          </div>
+        </ng-container>
+
         <!-- Analyzing -->
-        <ng-container *ngIf="currentStep === 2 && !hasFailed">
+        <ng-container *ngIf="currentStep === 2 && !hasFailed && jobStatus?.status !== 'preview_ready'">
           <mat-icon class="step-icon">analytics</mat-icon>
           <p>Generating aggregate analysis. This may take up to 10 minutes.</p>
         </ng-container>

--- a/frontend/src/app/components/processing-monitor/processing-monitor.component.scss
+++ b/frontend/src/app/components/processing-monitor/processing-monitor.component.scss
@@ -368,13 +368,11 @@
 
 @keyframes spin {
   from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
+  to { transform: rotate(-360deg); }
 }
 
-.step-icon {
-  &:not(.success):not(.error) {
-    animation: spin 2s linear infinite;
-  }
+.step-icon.spinning {
+  animation: spin 2s linear infinite;
 }
 
 .preview-section {

--- a/frontend/src/app/components/processing-monitor/processing-monitor.component.scss
+++ b/frontend/src/app/components/processing-monitor/processing-monitor.component.scss
@@ -376,3 +376,74 @@
     animation: spin 2s linear infinite;
   }
 }
+
+.preview-section {
+  text-align: left;
+  margin-top: $spacing-lg;
+
+  .preview-hint {
+    color: $color-gray-dark;
+    background-color: $color-secondary-light;
+    border-left: 3px solid $color-secondary;
+    padding: $spacing-md;
+    border-radius: $border-radius;
+    margin-bottom: $spacing-lg;
+  }
+
+  .preview-table-wrapper {
+    overflow-x: auto;
+    border: 1px solid $color-gray;
+    border-radius: $border-radius;
+    margin-bottom: $spacing-lg;
+  }
+
+  .preview-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: $font-size-breadcrumb;
+
+    th, td {
+      padding: $spacing-sm $spacing-md;
+      text-align: left;
+      vertical-align: top;
+      border-bottom: 1px solid $color-gray;
+    }
+
+    th {
+      background-color: $color-primary;
+      color: $color-white;
+      font-weight: $font-weight-bold;
+      position: sticky;
+      top: 0;
+    }
+
+    .preview-comment-cell {
+      max-width: 480px;
+      white-space: normal;
+      word-break: break-word;
+    }
+
+    tr:nth-child(even) td {
+      background-color: $color-secondary-light;
+    }
+  }
+
+  .preview-error {
+    display: flex;
+    align-items: center;
+    gap: $spacing-sm;
+    padding: $spacing-md;
+    background-color: color.adjust($color-error, $lightness: 50%);
+    border-left: 3px solid $color-error;
+    color: color.adjust($color-error, $lightness: -10%);
+    border-radius: $border-radius;
+    margin-bottom: $spacing-md;
+  }
+
+  .preview-actions {
+    display: flex;
+    gap: $spacing-md;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+  }
+}

--- a/frontend/src/app/components/processing-monitor/processing-monitor.component.spec.ts
+++ b/frontend/src/app/components/processing-monitor/processing-monitor.component.spec.ts
@@ -13,7 +13,7 @@ describe('ProcessingMonitorComponent', () => {
   let mockResultsService: jasmine.SpyObj<ResultsService>;
 
   beforeEach(async () => {
-    mockProcessingService = jasmine.createSpyObj('ProcessingService', ['pollStatus']);
+    mockProcessingService = jasmine.createSpyObj('ProcessingService', ['pollStatus', 'confirmPreview']);
     mockResultsService = jasmine.createSpyObj('ResultsService', ['getResults']);
 
     await TestBed.configureTestingModule({
@@ -262,6 +262,81 @@ describe('ProcessingMonitorComponent', () => {
 
       expect(component.hasFailed).toBeTruthy();
       expect(console.error).toHaveBeenCalled();
+    }));
+  });
+
+  describe('Preview Step', () => {
+    const previewStatus: JobStatus = {
+      status: 'preview_ready',
+      progress: 20,
+      completedRows: 20,
+      totalRows: 200,
+      previewRows: [
+        { comment: 'I support legalization', support: 'Support', _error: '' },
+        { comment: 'Cannabis should remain illegal', support: 'Oppose', _error: '' }
+      ],
+      analysisColumns: [{
+        name: 'support',
+        instructions: 'Pro: Support; Against: Oppose',
+        type: 'categorized',
+        options: [
+          { value: 'Support', description: 'In favor' },
+          { value: 'Oppose', description: 'Against' }
+        ]
+      }],
+      selectedCommentColumn: 'comment'
+    };
+
+    it('renders the preview table when status is preview_ready', fakeAsync(() => {
+      mockProcessingService.pollStatus.and.returnValue(of(previewStatus));
+
+      component.jobId = 'preview-job';
+      component.ngOnInit();
+      tick();
+      fixture.detectChanges();
+
+      const compiled = fixture.nativeElement as HTMLElement;
+      const previewTable = compiled.querySelector('.preview-table');
+      expect(previewTable).toBeTruthy();
+      expect(compiled.textContent).toContain('I support legalization');
+      expect(compiled.textContent).toContain('Cannabis should remain illegal');
+      expect(compiled.textContent).toContain('Support');
+      expect(compiled.textContent).toContain('Oppose');
+    }));
+
+    it('shows a confirm button when status is preview_ready', fakeAsync(() => {
+      mockProcessingService.pollStatus.and.returnValue(of(previewStatus));
+      component.jobId = 'preview-job';
+      component.ngOnInit();
+      tick();
+      fixture.detectChanges();
+
+      const compiled = fixture.nativeElement as HTMLElement;
+      const confirmBtn = compiled.querySelector('.confirm-preview-btn') as HTMLButtonElement;
+      expect(confirmBtn).toBeTruthy();
+    }));
+
+    it('calls confirmPreview when the confirm button is clicked', fakeAsync(() => {
+      mockProcessingService.pollStatus.and.returnValue(of(previewStatus));
+      mockProcessingService.confirmPreview.and.returnValue(of({ jobId: 'preview-job', status: 'processing' }));
+
+      component.jobId = 'preview-job';
+      component.ngOnInit();
+      tick();
+      fixture.detectChanges();
+
+      component.confirmPreview();
+      expect(mockProcessingService.confirmPreview).toHaveBeenCalledWith('preview-job');
+    }));
+
+    it('does not load results while in preview_ready state', fakeAsync(() => {
+      mockProcessingService.pollStatus.and.returnValue(of(previewStatus));
+      component.jobId = 'preview-job';
+      component.ngOnInit();
+      tick();
+
+      expect(component.isComplete).toBeFalse();
+      expect(mockResultsService.getResults).not.toHaveBeenCalled();
     }));
   });
 

--- a/frontend/src/app/components/processing-monitor/processing-monitor.component.ts
+++ b/frontend/src/app/components/processing-monitor/processing-monitor.component.ts
@@ -142,8 +142,12 @@ export class ProcessingMonitorComponent implements OnInit, OnDestroy {
             }
           } else if (status.status === 'failed') {
             this.hasFailed = true;
-            this.cdr.detectChanges(); // Force change detection
           }
+
+          // Angular 21 defaults to zoneless change detection, so HTTP callbacks
+          // don't auto-trigger CD. Force it after every status update so the
+          // stepper, progress bar, and preview UI all reflect the new state.
+          this.cdr.detectChanges();
         },
         error: (error) => {
           console.error('Error polling job status:', error);

--- a/frontend/src/app/components/processing-monitor/processing-monitor.component.ts
+++ b/frontend/src/app/components/processing-monitor/processing-monitor.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit, OnDestroy, ViewEncapsulation, ChangeDetectorRef, ViewChildren, QueryList, ElementRef, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { Router, ActivatedRoute } from '@angular/router';
+import { Router, ActivatedRoute, RouterModule } from '@angular/router';
 import { MatStepperModule } from '@angular/material/stepper';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatCardModule } from '@angular/material/card';
@@ -34,7 +34,8 @@ Chart.register(...registerables);
     MatProgressSpinnerModule,
     MatFormFieldModule,
     MatInputModule,
-    MatSnackBarModule
+    MatSnackBarModule,
+    RouterModule
   ],
   templateUrl: './processing-monitor.component.html',
   styleUrl: './processing-monitor.component.scss',
@@ -48,6 +49,8 @@ export class ProcessingMonitorComponent implements OnInit, OnDestroy {
   currentStep: number = 0;
   isComplete: boolean = false;
   hasFailed: boolean = false;
+  isConfirmingPreview: boolean = false;
+  previewError: string | null = null;
   private destroy$ = new Subject<void>();
 
   // Results
@@ -153,10 +156,33 @@ export class ProcessingMonitorComponent implements OnInit, OnDestroy {
   private updateStepFromStatus(status: JobStatus): void {
     switch (status.status) {
       case 'pending': this.currentStep = 0; break;
+      case 'preview_processing': this.currentStep = 1; break;
+      case 'preview_ready': this.currentStep = 1; break;
       case 'processing': this.currentStep = 1; break;
       case 'completed': this.currentStep = 2; break; // Stay on "Analyzing" until results load
       case 'failed': this.currentStep = 1; break;
     }
+  }
+
+  confirmPreview(): void {
+    if (!this.jobId || this.isConfirmingPreview) return;
+    this.isConfirmingPreview = true;
+    this.previewError = null;
+    this.processingService.confirmPreview(this.jobId).subscribe({
+      next: () => {
+        // Polling continues automatically — the next /status response will flip
+        // the job out of preview_ready into processing.
+        this.isConfirmingPreview = false;
+        this.cdr.detectChanges();
+      },
+      error: (err) => {
+        console.error('Failed to confirm preview:', err);
+        this.previewError = err.error?.error?.message
+          || 'Failed to start full processing. Please try again.';
+        this.isConfirmingPreview = false;
+        this.cdr.detectChanges();
+      }
+    });
   }
 
   loadResults(): void {
@@ -219,11 +245,22 @@ export class ProcessingMonitorComponent implements OnInit, OnDestroy {
     if (!this.jobStatus) return 'Initializing...';
     switch (this.jobStatus.status) {
       case 'pending': return 'Preparing to process your file...';
+      case 'preview_processing': return `Classifying first ${this.jobStatus.totalRows} rows for preview...`;
+      case 'preview_ready': return 'Review the sample classifications below before continuing.';
       case 'processing': return `Processing ${this.jobStatus.completedRows} of ${this.jobStatus.totalRows} rows...`;
       case 'completed': return 'Processing complete!';
       case 'failed': return this.jobStatus.error || 'Processing failed. Please try again.';
       default: return 'Unknown status';
     }
+  }
+
+  get previewColumnNames(): string[] {
+    const cols = this.jobStatus?.analysisColumns || [];
+    return cols.map(c => c.name);
+  }
+
+  get previewCommentColumn(): string {
+    return this.jobStatus?.selectedCommentColumn || 'comment';
   }
 
   generateDashboard(): void {

--- a/frontend/src/app/services/processing.service.ts
+++ b/frontend/src/app/services/processing.service.ts
@@ -8,11 +8,17 @@ export interface CategoryOption {
   description: string;
 }
 
+export interface CategoryExample {
+  commentText: string;
+  label: string;
+}
+
 export interface AnalysisColumn {
   name: string;
   instructions: string;
   type: 'open_text' | 'categorized';
   options?: CategoryOption[];
+  examples?: CategoryExample[];
 }
 
 export interface ProcessingRequest {

--- a/frontend/src/app/services/processing.service.ts
+++ b/frontend/src/app/services/processing.service.ts
@@ -33,12 +33,23 @@ export interface ProcessingResponse {
   status: string;
 }
 
+export type JobStatusValue =
+  | 'pending'
+  | 'preview_processing'
+  | 'preview_ready'
+  | 'processing'
+  | 'completed'
+  | 'failed';
+
 export interface JobStatus {
-  status: 'pending' | 'processing' | 'completed' | 'failed';
+  status: JobStatusValue;
   progress: number;
   completedRows: number;
   totalRows: number;
   error?: string;
+  previewRows?: Array<Record<string, string>>;
+  analysisColumns?: AnalysisColumn[];
+  selectedCommentColumn?: string;
 }
 
 @Injectable({
@@ -58,10 +69,21 @@ export class ProcessingService {
   }
 
   pollStatus(jobId: string, intervalMs: number = 2000): Observable<JobStatus> {
+    // Keep polling through every non-terminal state. preview_ready is non-terminal
+    // because the user can confirm and we want polling to continue post-confirmation.
+    const nonTerminal = new Set<JobStatusValue>([
+      'pending', 'preview_processing', 'preview_ready', 'processing'
+    ]);
     return interval(intervalMs).pipe(
-      startWith(0), // Emit immediately, then at intervals
+      startWith(0),
       switchMap(() => this.getStatus(jobId)),
-      takeWhile(status => status.status === 'pending' || status.status === 'processing', true)
+      takeWhile(status => nonTerminal.has(status.status), true)
+    );
+  }
+
+  confirmPreview(jobId: string): Observable<ProcessingResponse> {
+    return this.http.post<ProcessingResponse>(
+      `${this.apiUrl}/process/${jobId}/preview-confirm`, {}
     );
   }
 }

--- a/infrastructure/stacks/public_comment_analyzer_stack.py
+++ b/infrastructure/stacks/public_comment_analyzer_stack.py
@@ -586,7 +586,29 @@ class PublicCommentAnalyzerStack(Stack):
                 apigateway.MethodResponse(status_code="500")
             ]
         )
-        
+
+        # POST /api/process/{jobId}/preview-confirm - user confirms the preview classifications
+        # are reasonable; row processor then re-runs against the full file.
+        process_job_resource = process_resource.add_resource("{jobId}")
+        process_preview_confirm_resource = process_job_resource.add_resource("preview-confirm")
+        process_preview_confirm_resource.add_method(
+            "POST",
+            apigateway.LambdaIntegration(self.row_processor, proxy=True),
+            request_parameters={"method.request.path.jobId": True},
+            method_responses=[
+                apigateway.MethodResponse(
+                    status_code="200",
+                    response_parameters={
+                        "method.response.header.Access-Control-Allow-Origin": True
+                    }
+                ),
+                apigateway.MethodResponse(status_code="400"),
+                apigateway.MethodResponse(status_code="404"),
+                apigateway.MethodResponse(status_code="409"),
+                apigateway.MethodResponse(status_code="500")
+            ]
+        )
+
         # GET /api/status/{jobId} - query DynamoDB for job status
         status_resource = api_resource.add_resource("status")
         status_job_resource = status_resource.add_resource("{jobId}")

--- a/scripts/local-api.py
+++ b/scripts/local-api.py
@@ -162,6 +162,8 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
             return 'PublicCommentAnalyzer-StatusHandler-dev'
         if path == '/api/process' and method == 'POST':
             return 'PublicCommentAnalyzer-RowProcessor-dev'
+        if path.startswith('/api/process/') and path.endswith('/preview-confirm') and method == 'POST':
+            return 'PublicCommentAnalyzer-RowProcessor-dev'
         if path.startswith('/api/results/') and method == 'GET':
             return 'PublicCommentAnalyzer-AggregateAnalyzer-dev'
         if path.startswith('/api/dashboard/') and method == 'POST':
@@ -182,6 +184,11 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
             job_id = path.split('/api/dashboard/', 1)[1].rstrip('/')
             if job_id:
                 return {'jobId': job_id}
+        if path.startswith('/api/process/') and path.endswith('/preview-confirm'):
+            # /api/process/{jobId}/preview-confirm
+            middle = path[len('/api/process/'):-len('/preview-confirm')].rstrip('/')
+            if middle:
+                return {'jobId': middle}
         return None
 
     def do_GET(self):


### PR DESCRIPTION
## Summary

Investigation prompted by user feedback that the cannabis 1-7 scale classifications "don't fully grasp" the rubric. Three forces converge:

1. **The rubric itself is poisoned** — bucket 6's description literally says "This is the default for comments that say 'Legalize it'" which made 67% of all 3,042 cannabis comments land in bucket 6. The user team needs to fix this; a customer memo is in the plan file.
2. **Bedrock was using default temperature (~1.0)** so identical inputs landed in different buckets across runs, making any spot-check non-reproducible.
3. **No way to provide examples** — categorized columns had only descriptions to go on, no exemplars.
4. **No early validation** — users only saw classifications after a full 3,000-row run completed.

This PR addresses all the tool-side levers. The customer memo (Track A in the plan file) is separate.

### Backend (row_processor)
- **Pin `temperature=0`** on every Bedrock call when any categorized column is present, and on every per-column retry. Open-text-only runs keep Bedrock's default to preserve summary variety.
- **Few-shot examples**: new optional `examples: [{commentText, label}]` field on categorized columns. Up to 5 per column, label must match an option value, rendered into the prompt as `<examples><example>...</example></examples>` before the comment data. Largest single accuracy lever for nuanced taxonomies.
- **Preview gating phase**: for files ≥50 rows with categorized columns, the row processor now classifies the first 20 rows, persists them on the job record, flips status to `preview_ready`, and stops. The user reviews in the UI and clicks Confirm to continue. New `phase` field on the async invocation (`preview` / `confirm` / `full`) and new `POST /api/process/{jobId}/preview-confirm` endpoint.

### Backend (status_handler)
- Surface `previewRows` + `analysisColumns` + `selectedCommentColumn` in the status response when state is `preview_ready` so the frontend can render the table.
- Added test coverage for the handler (file previously had none).

### Frontend
- `column-definition` component: UI for managing 0-5 examples per categorized column with autocomplete from option values; round-trip on edit.
- `column-definition` component: inline lint warnings on option descriptions for poison words (`default`, `usually`, `most likely`, `the answer`, `obviously`) and a structural warning for >5 categories.
- `processing-monitor` component: renders the preview table, "Confirm and process all" button, "Cancel and revise" link. New status messages.
- `ProcessingService`: `confirmPreview(jobId)` method, extended `JobStatus` interface, polling continues across `preview_processing` / `preview_ready`.

### Infrastructure
- New API Gateway resource `POST /api/process/{jobId}/preview-confirm` wired to the row_processor lambda.

### CI
- Added `status_handler` to both GitHub Actions backend tests and the local pre-push hook so the new tests actually run.

## Test plan

- [x] Backend unit tests pass: row_processor (29), status_handler (3), upload_handler (11), aggregate_analyzer (14)
- [x] Frontend unit tests pass: 102/102 across all components
- [x] Frontend production build succeeds
- [ ] Smoke test in the deployed dev environment: re-run the same cannabis input file (`a3129344-…`) with the same 1-7 rubric. Expect (a) determinism between two consecutive runs (was ~5-15% drift), (b) preview UI gates the run and shows the first 20 rows, (c) lint warning appears on bucket 6's description.
- [ ] Hand-label 30 random rows against the rubric and compare to AI labels — only real accuracy measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)