### PR TITLE
OAIP-59: Raise categorized example cap from 5 to 14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ samconfig.toml
 # Playwright MCP artifacts
 .playwright-mcp/
 e2e-*.png
+
+# Eval harness outputs (raw downloads + reports per iteration)
+scripts/eval_results/

--- a/backend/row_processor/handler.py
+++ b/backend/row_processor/handler.py
@@ -276,7 +276,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 # Optional few-shot examples: each must pair a comment with a label
                 # and the label must reference a defined option value.
                 examples = col.get('examples') or []
-                MAX_EXAMPLES_PER_COLUMN = 5
+                MAX_EXAMPLES_PER_COLUMN = 14
                 MAX_EXAMPLE_TEXT_LENGTH = 2000
                 if len(examples) > MAX_EXAMPLES_PER_COLUMN:
                     return {

--- a/backend/row_processor/test_handler.py
+++ b/backend/row_processor/test_handler.py
@@ -355,7 +355,7 @@ class TestRowProcessorHandler(unittest.TestCase):
         self.assertEqual(body['error']['code'], 'INVALID_EXAMPLE')
 
     def test_too_many_examples_returns_400(self):
-        """More than 5 examples per column is rejected."""
+        """More than 14 examples per column is rejected."""
         event = {
             'body': json.dumps({
                 'fileId': str(uuid.uuid4()),
@@ -369,7 +369,7 @@ class TestRowProcessorHandler(unittest.TestCase):
                         {'value': 'Oppose', 'description': 'Against'}
                     ],
                     'examples': [
-                        {'commentText': f'Example {i}', 'label': 'Support'} for i in range(6)
+                        {'commentText': f'Example {i}', 'label': 'Support'} for i in range(15)
                     ]
                 }]
             })

--- a/frontend/src/app/components/column-definition/column-definition.component.html
+++ b/frontend/src/app/components/column-definition/column-definition.component.html
@@ -90,7 +90,7 @@
 
           <div class="examples-section">
             <p class="options-hint">
-              Optional: add up to 5 example comments with the correct label. Few-shot examples are the single largest accuracy lever for nuanced taxonomies.
+              Optional: add up to 14 example comments with the correct label. Few-shot examples are the single largest accuracy lever for nuanced taxonomies.
             </p>
             <div formArrayName="examples">
               <div *ngFor="let example of examplesArray.controls; let ei = index"

--- a/frontend/src/app/components/column-definition/column-definition.component.spec.ts
+++ b/frontend/src/app/components/column-definition/column-definition.component.spec.ts
@@ -223,11 +223,11 @@ describe('ColumnDefinitionComponent', () => {
       expect(component.examplesArray.length).toBe(1);
     });
 
-    it('caps examples at 5 per column', () => {
-      for (let i = 0; i < 10; i++) {
+    it('caps examples at 14 per column', () => {
+      for (let i = 0; i < 20; i++) {
         component.addExample();
       }
-      expect(component.examplesArray.length).toBe(5);
+      expect(component.examplesArray.length).toBe(14);
     });
 
     it('persists examples on the saved categorized column', () => {

--- a/frontend/src/app/components/column-definition/column-definition.component.ts
+++ b/frontend/src/app/components/column-definition/column-definition.component.ts
@@ -94,7 +94,7 @@ export class ColumnDefinitionComponent implements OnInit {
     return this.columnForm.get('examples') as FormArray;
   }
 
-  static readonly MAX_EXAMPLES = 5;
+  static readonly MAX_EXAMPLES = 14;
 
   addExample(): void {
     if (this.examplesArray.length >= ColumnDefinitionComponent.MAX_EXAMPLES) return;


### PR DESCRIPTION
## Summary
- Raises `MAX_EXAMPLES_PER_COLUMN` (backend handler + test, frontend UI cap + spec + help text) from 5 → 14.
- Adds `scripts/eval_results/` to `.gitignore` (raw downloads + per-iteration reports from the eval harness).

## Why
Evaluation against 216 hand-labeled cannabis-policy comments plateaued at ~69% with the 5-example budget. The 6 ↔ 7 boundary needs ~2 boundary examples on each side simultaneously, but at 5 examples total the budget is split between 6 categories. Iterations that doubled-down on one side cratered the other (v2: 7-recall 82% / 6-recall 29% vs v11: 6-recall 88% / 7-recall 28%). 14 lets us carry two examples per category in nuanced taxonomies.

## Test plan
- [x] Backend test `test_too_many_examples_returns_400` updated to expect rejection at >14, passes locally.
- [x] Frontend test `caps examples at 14 per column` updated, passes locally.
- [ ] Re-run `scripts/eval_classification.py` with v14 rubric (14 examples) post-deploy and confirm accuracy lift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)