### PR TITLE
Security follow-ups: bcrypt + workflow permissions + deploy.js

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,10 @@ env:
   NODE_VERSION: '22'
   PYTHON_VERSION: '3.11'
 
+# Default to read-only; jobs that need more declare their own permissions block.
+permissions:
+  contents: read
+
 jobs:
   detect-changes:
     name: Detect Changes

--- a/backend/auth_handler/handler.py
+++ b/backend/auth_handler/handler.py
@@ -2,8 +2,7 @@
 
 import json
 import os
-import hmac
-import hashlib
+import bcrypt
 import boto3
 import logging
 
@@ -27,6 +26,7 @@ def _get_secrets_client():
 
 
 def _get_password_hash():
+    """Return the stored bcrypt hash (cached). Empty string means auth not configured."""
     global _cached_hash
     if _cached_hash is not None:
         return _cached_hash
@@ -47,6 +47,16 @@ def _get_password_hash():
         return ''
 
 
+def _verify_password(password: str, stored_hash: str) -> bool:
+    """Constant-time bcrypt verification. Fails closed on any malformed input."""
+    if not password or not stored_hash:
+        return False
+    try:
+        return bcrypt.checkpw(password.encode('utf-8'), stored_hash.encode('utf-8'))
+    except (ValueError, TypeError):
+        return False
+
+
 def lambda_handler(event, context):
     headers = {
         'Content-Type': 'application/json',
@@ -58,11 +68,10 @@ def lambda_handler(event, context):
         password = body.get('password', '')
         if not password:
             return {'statusCode': 401, 'headers': headers, 'body': json.dumps({'valid': False, 'message': 'Password is required'})}
-        input_hash = hashlib.sha256(password.encode('utf-8')).hexdigest()
         stored_hash = _get_password_hash()
         if not stored_hash:
             return {'statusCode': 500, 'headers': headers, 'body': json.dumps({'valid': False, 'message': 'Auth not configured'})}
-        if hmac.compare_digest(input_hash, stored_hash):
+        if _verify_password(password, stored_hash):
             return {'statusCode': 200, 'headers': headers, 'body': json.dumps({'valid': True})}
         else:
             return {'statusCode': 401, 'headers': headers, 'body': json.dumps({'valid': False, 'message': 'Invalid password'})}

--- a/backend/shared/auth.py
+++ b/backend/shared/auth.py
@@ -2,8 +2,7 @@
 
 import os
 import json
-import hmac
-import hashlib
+import bcrypt
 import boto3
 from botocore.exceptions import ClientError
 import logging
@@ -23,7 +22,10 @@ def _get_secrets_client():
 
 
 def _get_password_hash() -> str:
-    """Retrieve the access password hash from Secrets Manager (cached per Lambda instance)."""
+    """Retrieve the access password hash from Secrets Manager (cached per Lambda instance).
+
+    The stored value is a bcrypt hash string (e.g. "$2b$12$...").
+    """
     global _cached_password_hash
     if _cached_password_hash is not None:
         return _cached_password_hash
@@ -42,14 +44,20 @@ def _get_password_hash() -> str:
         return ''
 
 
-def _hash_password(password: str) -> str:
-    """Hash a password with SHA-256."""
-    return hashlib.sha256(password.encode('utf-8')).hexdigest()
+def _verify_password(password: str, stored_hash: str) -> bool:
+    """Constant-time bcrypt verification. Returns False on any malformed input."""
+    if not password or not stored_hash:
+        return False
+    try:
+        return bcrypt.checkpw(password.encode('utf-8'), stored_hash.encode('utf-8'))
+    except (ValueError, TypeError):
+        # Hash isn't a valid bcrypt string — fail closed.
+        return False
 
 
 def validate_access_key(event: dict) -> bool:
     """
-    Validate the X-Access-Key header against the stored password hash.
+    Validate the X-Access-Key header against the stored bcrypt password hash.
 
     Returns True if valid, False otherwise. Fails closed: if no secret is
     configured and no LOCAL_PASSWORD_HASH is set, all requests are rejected.
@@ -60,21 +68,17 @@ def validate_access_key(event: dict) -> bool:
     if not access_key:
         return False
 
-    # Local-dev path: hash is provided directly via env var.
+    # Local-dev path: a bcrypt hash is provided directly via env var.
     local_hash = os.environ.get('LOCAL_PASSWORD_HASH', '')
     if local_hash:
-        return hmac.compare_digest(_hash_password(access_key), local_hash)
+        return _verify_password(access_key, local_hash)
 
     secret_name = os.environ.get('ACCESS_PASSWORD_SECRET_NAME', '')
     if not secret_name:
         logger.warning("Auth not configured: no ACCESS_PASSWORD_SECRET_NAME or LOCAL_PASSWORD_HASH set")
         return False
 
-    stored_hash = _get_password_hash()
-    if not stored_hash:
-        return False
-
-    return hmac.compare_digest(_hash_password(access_key), stored_hash)
+    return _verify_password(access_key, _get_password_hash())
 
 
 def build_unauthorized_response(cors_origin: str) -> dict:

--- a/backend/shared/requirements.txt
+++ b/backend/shared/requirements.txt
@@ -1,3 +1,4 @@
 boto3>=1.34.0
 openpyxl>=3.1.0
 chardet>=5.0.0
+bcrypt>=4.1.0

--- a/backend/shared/test_auth.py
+++ b/backend/shared/test_auth.py
@@ -1,9 +1,14 @@
 """Tests for the shared access-key validator."""
 
-import hashlib
 import importlib
 
+import bcrypt
 import pytest
+
+
+def _bcrypt(pw: str) -> str:
+    """Hash with bcrypt rounds=4 — fast for tests, never use this work factor in prod."""
+    return bcrypt.hashpw(pw.encode("utf-8"), bcrypt.gensalt(rounds=4)).decode("utf-8")
 
 
 @pytest.fixture
@@ -27,17 +32,17 @@ def test_fails_closed_when_no_secret_and_no_local_hash(auth):
 
 
 def test_rejects_when_header_missing(auth, monkeypatch):
-    monkeypatch.setenv("LOCAL_PASSWORD_HASH", hashlib.sha256(b"pw").hexdigest())
+    monkeypatch.setenv("LOCAL_PASSWORD_HASH", _bcrypt("pw"))
     assert auth.validate_access_key(_event(None)) is False
 
 
 def test_local_hash_path_accepts_correct_password(auth, monkeypatch):
-    monkeypatch.setenv("LOCAL_PASSWORD_HASH", hashlib.sha256(b"correct-horse").hexdigest())
+    monkeypatch.setenv("LOCAL_PASSWORD_HASH", _bcrypt("correct-horse"))
     assert auth.validate_access_key(_event("correct-horse")) is True
 
 
 def test_local_hash_path_rejects_wrong_password(auth, monkeypatch):
-    monkeypatch.setenv("LOCAL_PASSWORD_HASH", hashlib.sha256(b"correct-horse").hexdigest())
+    monkeypatch.setenv("LOCAL_PASSWORD_HASH", _bcrypt("correct-horse"))
     assert auth.validate_access_key(_event("wrong-password")) is False
 
 
@@ -48,15 +53,22 @@ def test_secrets_manager_path_returns_false_when_secret_empty(auth, monkeypatch)
     assert auth.validate_access_key(_event("anything")) is False
 
 
-def test_uses_constant_time_compare(auth, monkeypatch):
-    """Sanity: hmac.compare_digest must be the comparator (not ==)."""
-    monkeypatch.setenv("LOCAL_PASSWORD_HASH", hashlib.sha256(b"pw").hexdigest())
-    called = {"compare_digest": False}
+def test_malformed_hash_fails_closed(auth, monkeypatch):
+    """A garbage stored hash must not throw or pass — return False."""
+    monkeypatch.setenv("LOCAL_PASSWORD_HASH", "not-a-bcrypt-hash")
+    assert auth.validate_access_key(_event("anything")) is False
 
-    def fake_compare(a, b):
-        called["compare_digest"] = True
-        return a == b
 
-    monkeypatch.setattr(auth.hmac, "compare_digest", fake_compare)
+def test_uses_bcrypt_checkpw(auth, monkeypatch):
+    """Sanity: bcrypt.checkpw must be the comparator (not == or hashlib)."""
+    monkeypatch.setenv("LOCAL_PASSWORD_HASH", _bcrypt("pw"))
+    called = {"checkpw": False}
+    real_checkpw = auth.bcrypt.checkpw
+
+    def fake_checkpw(pw_bytes, hash_bytes):
+        called["checkpw"] = True
+        return real_checkpw(pw_bytes, hash_bytes)
+
+    monkeypatch.setattr(auth.bcrypt, "checkpw", fake_checkpw)
     auth.validate_access_key(_event("pw"))
-    assert called["compare_digest"], "validate_access_key must use hmac.compare_digest"
+    assert called["checkpw"], "validate_access_key must use bcrypt.checkpw"

--- a/frontend/deploy.js
+++ b/frontend/deploy.js
@@ -13,7 +13,7 @@
  *   npm run deploy:dry-run      # Show what would be deployed without actually deploying
  */
 
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
@@ -67,7 +67,7 @@ function extractDistributionId(cloudFrontUrl) {
 // Check if AWS CLI is available
 function checkAwsCli() {
   try {
-    execSync('aws --version', { stdio: 'ignore' });
+    execFileSync('aws', ['--version'], { stdio: 'ignore' });
     return true;
   } catch (error) {
     console.error('❌ Error: AWS CLI is not installed or not in PATH');
@@ -87,17 +87,17 @@ function syncToS3(bucketName) {
   }
   
   console.log(`📦 Syncing files to S3 bucket: ${bucketName}`);
-  
+
   const awsProfile = process.env.AWS_PROFILE || 'default';
-  const syncCommand = `aws s3 sync ${distPath} s3://${bucketName}/ --delete --profile ${awsProfile}`;
-  
+  const syncArgs = ['s3', 'sync', distPath, `s3://${bucketName}/`, '--delete', '--profile', awsProfile];
+
   if (isDryRun) {
-    console.log(`   [DRY RUN] Would execute: ${syncCommand}`);
+    console.log(`   [DRY RUN] Would execute: aws ${syncArgs.join(' ')}`);
     return;
   }
-  
+
   try {
-    execSync(syncCommand, { stdio: 'inherit' });
+    execFileSync('aws', syncArgs, { stdio: 'inherit' });
     console.log('✅ Files synced successfully');
   } catch (error) {
     console.error('❌ Error syncing files to S3:', error.message);
@@ -108,22 +108,34 @@ function syncToS3(bucketName) {
 // Set cache control headers for static assets
 function setCacheHeaders(bucketName) {
   console.log('⚙️  Setting cache control headers...');
-  
-  // Set long cache for hashed files (JS, CSS with hashes)
-  const longCacheCommand = `aws s3 cp s3://${bucketName}/ s3://${bucketName}/ --recursive --exclude "*" --include "*.js" --include "*.css" --cache-control "public, max-age=31536000, immutable" --metadata-directive REPLACE`;
-  
-  // Set short cache for index.html
-  const shortCacheCommand = `aws s3 cp s3://${bucketName}/index.html s3://${bucketName}/index.html --cache-control "public, max-age=0, must-revalidate" --metadata-directive REPLACE`;
-  
+
+  const longCacheArgs = [
+    's3', 'cp',
+    `s3://${bucketName}/`, `s3://${bucketName}/`,
+    '--recursive',
+    '--exclude', '*',
+    '--include', '*.js',
+    '--include', '*.css',
+    '--cache-control', 'public, max-age=31536000, immutable',
+    '--metadata-directive', 'REPLACE',
+  ];
+
+  const shortCacheArgs = [
+    's3', 'cp',
+    `s3://${bucketName}/index.html`, `s3://${bucketName}/index.html`,
+    '--cache-control', 'public, max-age=0, must-revalidate',
+    '--metadata-directive', 'REPLACE',
+  ];
+
   if (isDryRun) {
     console.log(`   [DRY RUN] Would set long cache for JS/CSS files`);
     console.log(`   [DRY RUN] Would set short cache for index.html`);
     return;
   }
-  
+
   try {
-    execSync(longCacheCommand, { stdio: 'ignore' });
-    execSync(shortCacheCommand, { stdio: 'ignore' });
+    execFileSync('aws', longCacheArgs, { stdio: 'ignore' });
+    execFileSync('aws', shortCacheArgs, { stdio: 'ignore' });
     console.log('✅ Cache headers set successfully');
   } catch (error) {
     console.warn('⚠️  Warning: Could not set cache headers:', error.message);
@@ -139,17 +151,22 @@ function invalidateCloudFront(distributionId) {
   }
   
   console.log(`🔄 Invalidating CloudFront cache for distribution: ${distributionId}`);
-  
+
   const awsProfile = process.env.AWS_PROFILE || 'default';
-  const invalidateCommand = `aws cloudfront create-invalidation --distribution-id ${distributionId} --paths "/*" --profile ${awsProfile}`;
-  
+  const invalidateArgs = [
+    'cloudfront', 'create-invalidation',
+    '--distribution-id', distributionId,
+    '--paths', '/*',
+    '--profile', awsProfile,
+  ];
+
   if (isDryRun) {
-    console.log(`   [DRY RUN] Would execute: ${invalidateCommand}`);
+    console.log(`   [DRY RUN] Would execute: aws ${invalidateArgs.join(' ')}`);
     return;
   }
-  
+
   try {
-    execSync(invalidateCommand, { stdio: 'inherit' });
+    execFileSync('aws', invalidateArgs, { stdio: 'inherit' });
     console.log('✅ CloudFront cache invalidation initiated');
   } catch (error) {
     console.error('❌ Error invalidating CloudFront cache:', error.message);

--- a/infrastructure/stacks/public_comment_analyzer_stack.py
+++ b/infrastructure/stacks/public_comment_analyzer_stack.py
@@ -706,6 +706,7 @@ class PublicCommentAnalyzerStack(Stack):
             runtime=lambda_.Runtime.PYTHON_3_11,
             handler="handler.lambda_handler",
             code=lambda_.Code.from_asset("../backend/auth_handler"),
+            layers=[self.shared_layer],   # bcrypt + shared auth helpers
             role=self.lambda_role,
             timeout=Duration.seconds(10),
             environment={


### PR DESCRIPTION
Follow-ups to PR #24 addressing the CodeQL alerts that were left open.

## Summary

### Trivial fixes (1 commit)
- **Workflow permissions**: deploy.yml now declares `permissions: contents: read` at the top level so jobs don't inherit the broad default GITHUB_TOKEN scope. Closes 6 identical CodeQL alerts.
- **deploy.js shell injection**: replaced 5 `execSync` calls (which interpolated env values into shell strings) with `execFileSync` + args arrays. Closes the "Shell command built from environment values" alert.

### Design-level: bcrypt migration (1 commit)
SHA-256 with no salt and no work factor was unsuitable for password storage — offline brute-force trivial if the secret leaks.

- Add `bcrypt>=4.1.0` to the shared layer; the CDK bundler already cross-compiles for `manylinux2014` on macOS so the C extension lands in Lambda cleanly.
- Wire the shared layer into AuthHandler (it didn't have it — only stdlib + boto3 in the runtime).
- Both auth paths (`auth_handler/handler.py`, `shared/auth.py`) now use `bcrypt.checkpw`. Constant-time internally, so the `hmac.compare_digest` guard goes away.
- `_verify_password` fails closed on malformed hashes (catches `ValueError`/`TypeError` from bcrypt).
- `test_auth` gains 2 new tests: malformed-hash-fails-closed, and a sanity check that `bcrypt.checkpw` is the comparator.

## Test plan
- [x] Backend: 110 tests pass (added 2 new auth tests, kept existing 6).
- [x] Local LOCAL_PASSWORD_HASH updated to bcrypt format so local dev still works.
- [x] Python syntax check on all modified files.

## Migration on merge

Same dance as PR #24:
1. PR merges → deploy runs.
2. CFN resets the secret to `{"password_hash":""}` (the CDK still seeds it empty).
3. Old code paths (still SHA-256 in the deployed Lambdas until this deploy lands) wouldn't validate the empty hash either — so no change in user-visible state during the deploy itself.
4. The moment deploy completes, run:
   ```bash
   aws secretsmanager put-secret-value \
     --secret-id PublicCommentAnalyzer-AccessPassword-dev \
     --secret-string '{"password_hash":"<bcrypt of WPlR1hhRlaUWjiHUXg4kf9>"}' \
     --profile ncdit
   ```
   I have the pre-computed bcrypt hash ready.
5. Verify with `curl -X POST .../api/auth/validate -d '{"password":"WPlR..."}'`.

Outage window: ~30s, same as last time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)