### PR TITLE
fix: pin bcrypt to <4.1 for Lambda Python 3.11 (auth 502 hotfix)

### DIFF
--- a/backend/shared/requirements.txt
+++ b/backend/shared/requirements.txt
@@ -1,4 +1,4 @@
 boto3>=1.34.0
 openpyxl>=3.1.0
 chardet>=5.0.0
-bcrypt>=4.1.0
+bcrypt>=4.0,<4.1   # 4.1+ targets glibc 2.28, breaks Lambda Python 3.11 (AL2 / glibc 2.26)


### PR DESCRIPTION
Hotfix on top of #45.

bcrypt 4.1+ wheels target manylinux_2_28 (glibc 2.28). Lambda Python 3.11 runs on Amazon Linux 2 (glibc 2.26), so the dynamic linker can't satisfy the requirement and the auth Lambda fails to import:

```
[ERROR] Runtime.ImportModuleError: Unable to import module 'handler':
/lib64/libc.so.6: version `GLIBC_2.28' not found
(required by /opt/python/bcrypt/_bcrypt.abi3.so)
```

The 502s started the moment #45's deploy completed. This pin to bcrypt 4.0.x (manylinux2014, glibc 2.17 floor) restores auth.

Long-term fix would be to bump the Lambda runtime to Python 3.12 (AL2023, glibc 2.34) so we can stay on bcrypt 4.1+, but that's a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)