### PR TITLE
fix: bump Lambda runtime to Python 3.12 (auth still 502 after #46)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ env:
   ENVIRONMENT: ${{ github.event.inputs.environment || 'dev' }}
   HUSKY: 0
   NODE_VERSION: '22'
-  PYTHON_VERSION: '3.11'
+  PYTHON_VERSION: '3.12'
 
 # Default to read-only; jobs that need more declare their own permissions block.
 permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ export AWS_PROFILE=your-profile-name
 
 ### Python Environment
 - Always use `.venv` if present (check before creating new ones)
-- Python 3.11+ required
+- Python 3.12+ required (Lambda runtime is python3.12 on Amazon Linux 2023)
 - Backend uses shared modules in `backend/shared/`
 
 ## Architecture Patterns

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Focus the message on the **why**, not the what. The diff already shows what.
 
 ## Local development
 
-You'll need Python 3.11+, Node 20+, and Docker (for SAM local). See [README.md](./README.md#local-development) for the full SAM setup. Quick path:
+You'll need Python 3.12+, Node 20+, and Docker (for SAM local). See [README.md](./README.md#local-development) for the full SAM setup. Quick path:
 
 ```bash
 # Backend deps (per Lambda dir as needed)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ GitHub Actions CI/CD is wired up — every push to `main` auto-deploys to the AW
 - An AWS account you can deploy CloudFormation into.
 - **Bedrock model access** enabled in your target region (default: `us-east-1`) for **Claude Haiku** and **Claude Opus**. Console → Bedrock → Model access → Manage model access.
 - `cdk bootstrap` run once per region for the account.
-- Python 3.11+, Node 20+, AWS CLI, AWS CDK CLI.
+- Python 3.12+, Node 20+, AWS CLI, AWS CDK CLI.
 - (Optional) ACM certificate in `us-east-1` if you want a custom domain.
 
 ### Setup

--- a/backend/shared/requirements.txt
+++ b/backend/shared/requirements.txt
@@ -1,4 +1,4 @@
 boto3>=1.34.0
 openpyxl>=3.1.0
 chardet>=5.0.0
-bcrypt>=4.0,<4.1   # 4.1+ targets glibc 2.28, breaks Lambda Python 3.11 (AL2 / glibc 2.26)
+bcrypt>=4.1.0

--- a/infrastructure/stacks/public_comment_analyzer_stack.py
+++ b/infrastructure/stacks/public_comment_analyzer_stack.py
@@ -49,7 +49,7 @@ class _PipBundling:
             # On non-Linux (e.g. macOS), cross-compile for Lambda's Linux runtime
             import platform
             if platform.system() != "Linux":
-                cmd[2:2] = ["--platform", "manylinux2014_x86_64", "--only-binary=:all:"]
+                cmd[2:2] = ["--platform", "manylinux_2_28_x86_64", "--only-binary=:all:"]
             subprocess.check_call(cmd)
         # Copy source files (exclude test files and copy_shared.sh)
         import shutil
@@ -89,7 +89,7 @@ class _LayerBundling:
                 "-r", req_file,
             ]
             if platform.system() != "Linux":
-                cmd[2:2] = ["--platform", "manylinux2014_x86_64", "--only-binary=:all:"]
+                cmd[2:2] = ["--platform", "manylinux_2_28_x86_64", "--only-binary=:all:"]
             subprocess.check_call(cmd)
 
         # Copy shared Python modules (exclude tests)
@@ -318,11 +318,11 @@ class PublicCommentAnalyzerStack(Stack):
             "SharedLayer",
             layer_version_name=f"PublicCommentAnalyzer-Shared-{self.env_name}",
             description="Shared modules for Public Comment Analyzer Lambda functions",
-            compatible_runtimes=[lambda_.Runtime.PYTHON_3_11],
+            compatible_runtimes=[lambda_.Runtime.PYTHON_3_12],
             code=lambda_.Code.from_asset(
                 "../backend/shared",
                 bundling=BundlingOptions(
-                    image=lambda_.Runtime.PYTHON_3_11.bundling_image,
+                    image=lambda_.Runtime.PYTHON_3_12.bundling_image,
                     command=[
                         "bash", "-c",
                         "mkdir -p /asset-output/python && "
@@ -342,12 +342,12 @@ class PublicCommentAnalyzerStack(Stack):
             self,
             "UploadHandler",
             function_name=f"PublicCommentAnalyzer-UploadHandler-{self.env_name}",
-            runtime=lambda_.Runtime.PYTHON_3_11,
+            runtime=lambda_.Runtime.PYTHON_3_12,
             handler="handler.lambda_handler",
             code=lambda_.Code.from_asset(
                 "../backend/upload_handler",
                 bundling=BundlingOptions(
-                    image=lambda_.Runtime.PYTHON_3_11.bundling_image,
+                    image=lambda_.Runtime.PYTHON_3_12.bundling_image,
                     command=[
                         "bash", "-c",
                         "pip install -r requirements.txt -t /asset-output && cp -au . /asset-output"
@@ -376,12 +376,12 @@ class PublicCommentAnalyzerStack(Stack):
             self,
             "RowProcessor",
             function_name=f"PublicCommentAnalyzer-RowProcessor-{self.env_name}",
-            runtime=lambda_.Runtime.PYTHON_3_11,
+            runtime=lambda_.Runtime.PYTHON_3_12,
             handler="handler.lambda_handler",
             code=lambda_.Code.from_asset(
                 "../backend/row_processor",
                 bundling=BundlingOptions(
-                    image=lambda_.Runtime.PYTHON_3_11.bundling_image,
+                    image=lambda_.Runtime.PYTHON_3_12.bundling_image,
                     command=[
                         "bash", "-c",
                         "pip install -r requirements.txt -t /asset-output && cp -au . /asset-output"
@@ -413,12 +413,12 @@ class PublicCommentAnalyzerStack(Stack):
             self,
             "AggregateAnalyzer",
             function_name=f"PublicCommentAnalyzer-AggregateAnalyzer-{self.env_name}",
-            runtime=lambda_.Runtime.PYTHON_3_11,
+            runtime=lambda_.Runtime.PYTHON_3_12,
             handler="handler.lambda_handler",
             code=lambda_.Code.from_asset(
                 "../backend/aggregate_analyzer",
                 bundling=BundlingOptions(
-                    image=lambda_.Runtime.PYTHON_3_11.bundling_image,
+                    image=lambda_.Runtime.PYTHON_3_12.bundling_image,
                     command=[
                         "bash", "-c",
                         "pip install -r requirements.txt -t /asset-output && cp -au . /asset-output"
@@ -447,12 +447,12 @@ class PublicCommentAnalyzerStack(Stack):
             self,
             "DashboardGenerator",
             function_name=f"PublicCommentAnalyzer-DashboardGenerator-{self.env_name}",
-            runtime=lambda_.Runtime.PYTHON_3_11,
+            runtime=lambda_.Runtime.PYTHON_3_12,
             handler="handler.lambda_handler",
             code=lambda_.Code.from_asset(
                 "../backend/dashboard_generator",
                 bundling=BundlingOptions(
-                    image=lambda_.Runtime.PYTHON_3_11.bundling_image,
+                    image=lambda_.Runtime.PYTHON_3_12.bundling_image,
                     command=[
                         "bash", "-c",
                         "pip install -r requirements.txt -t /asset-output && cp -au . /asset-output"
@@ -620,7 +620,7 @@ class PublicCommentAnalyzerStack(Stack):
             self,
             "StatusHandler",
             function_name=f"PublicCommentAnalyzer-StatusHandler-{self.env_name}",
-            runtime=lambda_.Runtime.PYTHON_3_11,
+            runtime=lambda_.Runtime.PYTHON_3_12,
             handler="handler.lambda_handler",
             code=lambda_.Code.from_asset("../backend/status_handler"),
             layers=[self.shared_layer],
@@ -703,7 +703,7 @@ class PublicCommentAnalyzerStack(Stack):
             self,
             "AuthHandler",
             function_name=f"PublicCommentAnalyzer-AuthHandler-{self.env_name}",
-            runtime=lambda_.Runtime.PYTHON_3_11,
+            runtime=lambda_.Runtime.PYTHON_3_12,
             handler="handler.lambda_handler",
             code=lambda_.Code.from_asset("../backend/auth_handler"),
             layers=[self.shared_layer],   # bcrypt + shared auth helpers


### PR DESCRIPTION
The auth 502s from after #45 didn't actually clear with #46. The bcrypt wheel — even 4.0.1 — uses `statx@GLIBC_2.28` despite advertising `manylinux2014` (glibc 2.17). AL2 (Lambda Python 3.11) only has glibc 2.26.

Bumping every Lambda runtime to Python 3.12 (Amazon Linux 2023, glibc 2.34) is the clean fix. Modern bcrypt + future deps just work.

## Changes

- Every `lambda_.Runtime.PYTHON_3_11` → `PYTHON_3_12` in `infrastructure/stacks/public_comment_analyzer_stack.py` (7 Lambdas + the shared layer's `compatible_runtimes`).
- `_PipBundling` and `_LayerBundling` cross-compile target: `manylinux2014_x86_64` → `manylinux_2_28_x86_64` so `pip` picks the wheels meant for AL2023.
- GH Actions `PYTHON_VERSION` env var: `3.11` → `3.12`.
- `backend/shared/requirements.txt`: revert the #46 pin (`bcrypt>=4.0,<4.1` → `bcrypt>=4.1.0`).
- README / AGENTS.md / CONTRIBUTING.md updated to say "Python 3.12+".

## Verified
- All 110 backend tests pass locally.
- All non-bcrypt deps (boto3, openpyxl, chardet) confirmed to ship py3.12 + manylinux_2_28 wheels.

## Post-merge dance
Same as before: deploy resets the secret to `{"password_hash":""}`, then I run `aws secretsmanager put-secret-value` with the (regenerated) bcrypt hash of the live password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)