### PR TITLE
OAIP-71: fix prod 401 loop on file upload

### DIFF
--- a/frontend/src/app/interceptors/auth.interceptor.spec.ts
+++ b/frontend/src/app/interceptors/auth.interceptor.spec.ts
@@ -1,0 +1,93 @@
+import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { authInterceptor } from './auth.interceptor';
+import { AuthService } from '../services/auth.service';
+
+const STORAGE_KEY = 'pca_access_key';
+const API = 'http://localhost:3000/api';
+
+describe('authInterceptor', () => {
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+  let authServiceSpy: jasmine.SpyObj<AuthService>;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+
+    authServiceSpy = jasmine.createSpyObj<AuthService>('AuthService', ['logout']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([authInterceptor])),
+        provideHttpClientTesting(),
+        { provide: AuthService, useValue: authServiceSpy }
+      ]
+    });
+
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    sessionStorage.clear();
+    localStorage.clear();
+  });
+
+  it('attaches X-Access-Key from sessionStorage on protected requests', () => {
+    sessionStorage.setItem(STORAGE_KEY, 'session-password');
+
+    http.get(`${API}/upload`).subscribe();
+    const req = httpMock.expectOne(`${API}/upload`);
+
+    expect(req.request.headers.get('X-Access-Key')).toBe('session-password');
+    req.flush({});
+  });
+
+  it('does NOT attach X-Access-Key when sessionStorage is empty', () => {
+    http.get(`${API}/upload`).subscribe();
+    const req = httpMock.expectOne(`${API}/upload`);
+
+    expect(req.request.headers.has('X-Access-Key')).toBeFalse();
+    req.flush({});
+  });
+
+  it('does NOT read from localStorage (storage source is pinned to sessionStorage)', () => {
+    // A localStorage value must not leak into the header. This guards against
+    // regressing commit d3bc1df, which moved auth.service.ts to sessionStorage
+    // but left the interceptor reading localStorage.
+    localStorage.setItem(STORAGE_KEY, 'leaked-from-localstorage');
+
+    http.get(`${API}/upload`).subscribe();
+    const req = httpMock.expectOne(`${API}/upload`);
+
+    expect(req.request.headers.has('X-Access-Key')).toBeFalse();
+    req.flush({});
+  });
+
+  it('does NOT attach X-Access-Key on /auth/validate even with sessionStorage set', () => {
+    sessionStorage.setItem(STORAGE_KEY, 'session-password');
+
+    http.post(`${API}/auth/validate`, { password: 'foo' }).subscribe();
+    const req = httpMock.expectOne(`${API}/auth/validate`);
+
+    expect(req.request.headers.has('X-Access-Key')).toBeFalse();
+    req.flush({ valid: true });
+  });
+
+  it('calls AuthService.logout() when a protected request returns 401', () => {
+    sessionStorage.setItem(STORAGE_KEY, 'session-password');
+
+    http.get(`${API}/upload`).subscribe({
+      next: () => fail('expected 401 error'),
+      error: () => undefined
+    });
+    const req = httpMock.expectOne(`${API}/upload`);
+    req.flush({ error: 'Unauthorized' }, { status: 401, statusText: 'Unauthorized' });
+
+    expect(authServiceSpy.logout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/app/interceptors/auth.interceptor.ts
+++ b/frontend/src/app/interceptors/auth.interceptor.ts
@@ -7,7 +7,7 @@ const ACCESS_KEY_STORAGE_KEY = 'pca_access_key';
 
 export const authInterceptor: HttpInterceptorFn = (req, next) => {
   const authService = inject(AuthService);
-  const accessKey = localStorage.getItem(ACCESS_KEY_STORAGE_KEY);
+  const accessKey = sessionStorage.getItem(ACCESS_KEY_STORAGE_KEY);
 
   // Don't attach the key to the auth/validate call itself
   if (accessKey && !req.url.includes('/auth/validate')) {


### PR DESCRIPTION
## Summary

Production at `commentreviewer.oaip.nc.gov` has been in a login loop since `d3bc1df` (2026-05-04). The auth interceptor still reads `localStorage`, but `auth.service.ts` was migrated to `sessionStorage` in that commit — so every protected API call goes out without the `X-Access-Key` header, the backend returns 401, and the interceptor's 401 handler logs the user out. Repeat.

One-line fix: `localStorage.getItem` → `sessionStorage.getItem` in `frontend/src/app/interceptors/auth.interceptor.ts:10`. Plus a spec to pin the storage source so a future revert can't pass tests silently.

Jira: [OAIP-71](https://ncdigitalservices.atlassian.net/browse/OAIP-71)

## Root cause

`d3bc1df` ("vuln: store auth token in sessionStorage instead of localStorage") updated `auth.service.ts` (4 sites — write/read/has-key/logout) but missed the interceptor's read on line 10. CloudWatch confirms the upload Lambda exits via `validate_access_key()` → `build_unauthorized_response()` (`backend/upload_handler/handler.py:191-192`) for every request — the header simply never arrives.

Backend auth (`backend/shared/auth.py` and `backend/auth_handler/handler.py`) is correct on bcrypt; this is purely client-side.

## Test plan

- [x] `npm test` — 107/107 pass (was 102; my 5 new specs added)
- [ ] Reviewer: hard-refresh `commentreviewer.oaip.nc.gov` after merge + CloudFront invalidation
- [ ] Reviewer: enter password → DevTools → Application → confirm `pca_access_key` lives in **Session Storage** only
- [ ] Reviewer: upload a small CSV → DevTools → Network → confirm `POST /api/upload` request includes `X-Access-Key` header and returns 200
- [ ] Reviewer: continue through column-definition + processing → confirm full flow works end to end
- [ ] Reviewer: close tab, reopen → confirm sessionStorage clears and access-gate appears (designed-by-d3bc1df behavior intact)

## Out of scope

- The dev/prod environment confusion — `commentreviewer.oaip.nc.gov` is fronted by `-dev` Lambdas and there is no real `-prod` deployment. Worth a separate ticket.
- Replacing the raw-password-in-storage pattern with an opaque server-issued token. Bigger rework, follow-up if/when this app gets more users.

[OAIP-71]: https://ncdigitalservices.atlassian.net/browse/OAIP-71?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ