### PR TITLE
OAIP-73: unstall processing UI on Queued (status polling fix)

### DIFF
--- a/frontend/src/app/services/processing.service.spec.ts
+++ b/frontend/src/app/services/processing.service.spec.ts
@@ -1,0 +1,98 @@
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+
+import { JobStatus, ProcessingService } from './processing.service';
+
+const API = 'http://localhost:3000/api';
+const STATUS_URL = (jobId: string) => `${API}/status/${jobId}`;
+
+function statusResponse(overrides: Partial<JobStatus> = {}): JobStatus {
+  return {
+    status: 'preview_ready',
+    progress: 16,
+    completedRows: 20,
+    totalRows: 125,
+    ...overrides
+  };
+}
+
+describe('ProcessingService.pollStatus', () => {
+  let service: ProcessingService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        ProcessingService,
+        provideHttpClient(),
+        provideHttpClientTesting()
+      ]
+    });
+    service = TestBed.inject(ProcessingService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('does NOT cancel an in-flight request when the next interval fires (regression for OAIP-73)', fakeAsync(() => {
+    const emitted: JobStatus[] = [];
+    const sub = service.pollStatus('job-1', 100).subscribe(s => emitted.push(s));
+
+    // First request fires immediately via startWith(0)
+    const req1 = httpMock.expectOne(STATUS_URL('job-1'));
+
+    // Advance past the next interval tick BEFORE responding to req1.
+    // With switchMap this would cancel req1; with concatMap req1 must complete
+    // before the next request fires.
+    tick(150);
+
+    // req1 is still open — confirm by responding now and seeing it land.
+    req1.flush(statusResponse({ status: 'preview_ready' }));
+
+    expect(emitted.length).toBe(1);
+    expect(emitted[0].status).toBe('preview_ready');
+
+    // After req1 completes, concatMap immediately emits the queued tick.
+    const req2 = httpMock.expectOne(STATUS_URL('job-1'));
+    req2.flush(statusResponse({ status: 'completed', progress: 100, completedRows: 125 }));
+
+    expect(emitted.length).toBe(2);
+    expect(emitted[1].status).toBe('completed');
+
+    sub.unsubscribe();
+  }));
+
+  it('stops polling once a terminal status arrives', fakeAsync(() => {
+    const emitted: JobStatus[] = [];
+    const sub = service.pollStatus('job-2', 100).subscribe(s => emitted.push(s));
+
+    httpMock.expectOne(STATUS_URL('job-2')).flush(statusResponse({ status: 'completed', progress: 100 }));
+
+    // Advance several intervals — no further requests should fire.
+    tick(500);
+    httpMock.expectNone(STATUS_URL('job-2'));
+
+    expect(emitted.length).toBe(1);
+    expect(emitted[0].status).toBe('completed');
+
+    sub.unsubscribe();
+  }));
+
+  it('keeps polling through preview_ready (non-terminal — user must confirm)', fakeAsync(() => {
+    const emitted: JobStatus[] = [];
+    const sub = service.pollStatus('job-3', 100).subscribe(s => emitted.push(s));
+
+    httpMock.expectOne(STATUS_URL('job-3')).flush(statusResponse({ status: 'preview_ready' }));
+    tick(100);
+
+    // A second poll must fire after preview_ready.
+    httpMock.expectOne(STATUS_URL('job-3')).flush(statusResponse({ status: 'processing', progress: 50, completedRows: 62 }));
+
+    expect(emitted.length).toBe(2);
+    expect(emitted[0].status).toBe('preview_ready');
+    expect(emitted[1].status).toBe('processing');
+
+    sub.unsubscribe();
+  }));
+});

--- a/frontend/src/app/services/processing.service.ts
+++ b/frontend/src/app/services/processing.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, interval, switchMap, takeWhile, startWith } from 'rxjs';
+import { Observable, interval, concatMap, takeWhile, startWith } from 'rxjs';
 import { environment } from '../../environments/environment';
 
 export interface CategoryOption {
@@ -74,9 +74,13 @@ export class ProcessingService {
     const nonTerminal = new Set<JobStatusValue>([
       'pending', 'preview_processing', 'preview_ready', 'processing'
     ]);
+    // concatMap (not switchMap) — when /api/status takes longer than intervalMs
+    // (it can on cold starts or under-provisioned memory), switchMap would
+    // cancel every in-flight request and the UI would never receive a status
+    // update. concatMap queues so each request completes before the next fires.
     return interval(intervalMs).pipe(
       startWith(0),
-      switchMap(() => this.getStatus(jobId)),
+      concatMap(() => this.getStatus(jobId)),
       takeWhile(status => nonTerminal.has(status.status), true)
     );
   }

--- a/infrastructure/stacks/public_comment_analyzer_stack.py
+++ b/infrastructure/stacks/public_comment_analyzer_stack.py
@@ -626,6 +626,10 @@ class PublicCommentAnalyzerStack(Stack):
             layers=[self.shared_layer],
             role=self.lambda_role,
             timeout=Duration.seconds(10),
+            # 512 MB so the bcrypt verify on every request stays under ~300 ms.
+            # The frontend polls /status every 2 s; at the Lambda default 128 MB
+            # each call took ~4 s and the polling pipeline stalled the UI.
+            memory_size=512,
             environment={
                 "JOBS_TABLE": self.jobs_table.table_name,
                 "ALLOWED_ORIGIN": self.allowed_origin,


### PR DESCRIPTION
## Summary

After OAIP-71 fixed the auth interceptor and users could finally reach `/processing/{jobId}`, the UI was getting stuck on "Queued" forever — no console logs, hard refresh didn't help. Backend was healthy throughout (preview ready in DDB within seconds).

Root cause is two issues stacking:
1. **`StatusHandler` is on 128 MB memory** → every `/api/status` call takes ~4s (bcrypt verify on every request). Confirmed in CloudWatch: `Duration: ~4100 ms` on every invocation, max memory used ~91 MB so it's CPU-bound, not memory-bound.
2. **Frontend polls every 2s with `switchMap`** → every in-flight request gets cancelled by the next interval emission before its response arrives. The `next:` handler never fires (which is why no console logs), `jobStatus` stays `null`, `currentStep` stays `0`, UI stays on "Queued."

Jira: [OAIP-73](https://ncdigitalservices.atlassian.net/browse/OAIP-73)

## Changes

- `frontend/src/app/services/processing.service.ts`: `switchMap` → `concatMap` so polls queue instead of cancel. Inline comment documents why.
- `frontend/src/app/services/processing.service.spec.ts` (new): 3 cases including a fakeAsync regression that fires a second interval tick *before* responding to the first request, asserting the first response still lands.
- `infrastructure/stacks/public_comment_analyzer_stack.py`: bump StatusHandler `memory_size` to 512 MB. Lambda CPU is allocated proportionally to memory; expected per-call latency drops from ~4s to ~300ms. Cost impact is single-digit dollars/month at this app's traffic.

## Test plan

- [x] `npm test` — 110/110 pass (was 107; added 3 new specs)
- [ ] Reviewer: after merge + auto-deploy, upload a small test file → confirm processing screen advances to the preview UI within ~5s of preview completion (no manual refresh needed)
- [ ] Reviewer: CloudWatch StatusHandler `Duration` < 1s on warm invocations
- [ ] Reviewer: full flow login → upload → preview → confirm → results download all work end-to-end

## Followups not in this PR

- The polling could move to SSE / websockets for instant updates (current 2s polling is fine but wasteful)
- StatusHandler could skip bcrypt and use a server-issued opaque session token, dropping the per-call latency further. Bigger rework.

[OAIP-73]: https://ncdigitalservices.atlassian.net/browse/OAIP-73?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ