### PR TITLE
OAIP-74: migrate CI from static AWS keys to OIDC role assumption

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,6 +77,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: detect-changes
     if: needs.detect-changes.outputs.backend == 'true' || needs.detect-changes.outputs.infrastructure == 'true'
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       frontend-bucket: ${{ steps.get-outputs.outputs.frontend-bucket }}
       cloudfront-dist: ${{ steps.get-outputs.outputs.cloudfront-dist }}
@@ -87,8 +90,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Set up Python
@@ -149,9 +151,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [detect-changes, deploy-infrastructure]
     if: |
-      always() && 
+      always() &&
       needs.detect-changes.outputs.frontend == 'true' &&
       (needs.deploy-infrastructure.result == 'success' || needs.deploy-infrastructure.result == 'skipped')
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -159,8 +164,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Set up Node.js


### PR DESCRIPTION
## Summary
- Closes the org-move task ([OAIP-74](https://ncdigitalservices.atlassian.net/browse/OAIP-74)). The repo has already been renamed `OAIP-Public-Comment-Reviewer` → `Public-Comment-Analyzer` and transferred from `State-of-North-Carolina-DIT` to `NC-DIT-Open-Source`.
- Drops the static AWS access key from `github-actions-deployer` IAM user and switches the workflow to assume `arn:aws:iam::267527030320:role/github-actions-deployer-oidc` via GitHub OIDC. Trust policy is pinned to `repo:NC-DIT-Open-Source/Public-Comment-Analyzer:*`.
- Repo secrets shrink from 5 to 4 (no more `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`; new `AWS_DEPLOY_ROLE_ARN`).

## Why
1. The trust policy has to be rebuilt anyway when you change `org/repo`, so this is the right time to move off long-lived credentials.
2. Static keys live forever until someone manually rotates them; OIDC tokens expire in ~1 hour, can't be exfiltrated, and are scoped to this exact repo.

## Test plan
- [ ] `workflow_dispatch` run from this branch reaches `Configure AWS credentials` and prints `Authenticated as ARN arn:aws:sts::267527030320:assumed-role/github-actions-deployer-oidc/GitHubActions...`
- [ ] `cdk deploy` produces no infra drift (same stack outputs as today)
- [ ] `aws s3 sync` and `cloudfront create-invalidation` both succeed
- [ ] After merge: `commentreviewer.oaip.nc.gov` still serves the app, login → upload → results works end-to-end
- [ ] Old IAM key `AKIAT4SO2QYYCHDFGTM3` flipped to `Inactive` once verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)