### PR TITLE
docs: purge NC-specific deployment URL from SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,7 @@ In scope:
 Out of scope:
 - Vulnerabilities in third-party dependencies — please report those upstream and let us know via a normal advisory so we can pin/patch.
 - Findings that require physical access, social engineering, or compromise of the deploying organization's AWS account.
-- Issues in NC DIT's specific deployment (`commentreviewer.oaip.nc.gov`) that are not reproducible against a fresh deploy of this repo. For those, contact NC DIT directly.
+- Issues in a specific operator's deployment that are not reproducible against a fresh deploy of this repo. For those, contact the operator of that deployment directly.
 
 ## Supported versions
 


### PR DESCRIPTION
## Summary
- Pre-open-source reviewer flagged the named NC DIT production host (`commentreviewer.oaip.nc.gov`) in `SECURITY.md`.
- Reworded the out-of-scope bullet so it applies generically to any operator's deployment instead of pointing at one operator.

## Test plan
- [x] `grep -n "commentreviewer.oaip.nc.gov\|NC DIT" SECURITY.md` returns no matches
- [x] Bullet still conveys the original scope boundary (per-operator-deployment bugs aren't this project's responsibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)