### PR TITLE
docs: purge NC-specific deployment URL from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A serverless AWS application that processes CSV/XLSX files of public comments and generates AI per-row analysis plus an aggregate summary using AWS Bedrock (Claude).
 
-NC DIT operates a reference instance at [commentreviewer.oaip.nc.gov](https://commentreviewer.oaip.nc.gov) for use by NC state employees — public access is restricted to a private beta run by OAIP. To run it yourself, deploy your own copy to your own AWS account using the steps below.
+To run it yourself, deploy your own copy to your own AWS account using the steps below.
 
 **Cost note**: Pay-per-token Bedrock plus standard AWS infra. Roughly **$2-5 per 1,000 comments** depending on column count and aggregate complexity. S3 lifecycle deletes uploads after 7 days.
 


### PR DESCRIPTION
## Summary
- Removes the sentence in `README.md` that named NC DIT's reference deployment (`commentreviewer.oaip.nc.gov`).
- Companion to #60 which removed the same identifier from `SECURITY.md`.
- Note: a follow-up `git filter-repo` will scrub the literal from history (force-push to `main`); see local notes.

## Test plan
- [x] `grep -n "commentreviewer.oaip.nc.gov" README.md` returns no matches
- [x] Surrounding paragraphs still flow (no orphaned references)

🤖 Generated with [Claude Code](https://claude.com/claude-code)