### PR TITLE
OAIP-89: restructure README local dev section

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,39 +116,73 @@ graph TD
 
 ## Local development
 
-You can run the full stack locally with AWS SAM CLI — Lambdas execute in Docker on your machine while still calling real AWS services (S3, DynamoDB, Bedrock) via your AWS profile. You don't need to run `cdk bootstrap` or `cdk deploy` for this — the account just needs to have been deployed to once already (someone else's job, or yours from the steps above).
+Run the full stack on your machine: Lambdas execute in Docker via AWS SAM CLI but still call real AWS services (S3, DynamoDB, Bedrock) using your AWS profile. The account just needs to have been deployed to once already — you don't need to run `cdk bootstrap` or `cdk deploy` yourself.
 
-### Minimum AWS permissions
+### Prereqs
 
-The IAM principal whose creds you're using locally needs `bedrock:InvokeModel` on the Claude Haiku/Opus model + inference-profile ARNs, plus read/write on the deployed `public-comment-analyzer-data-<env>-<account>` S3 bucket and `PublicCommentAnalyzer-Jobs-<env>` DynamoDB table. `ssm:GetParameter` on `/cdk-bootstrap/*` is needed if you'll re-synth the CDK template locally. Bedrock model access for Claude Haiku and Claude Opus must also be enabled in your region (Console → Bedrock → Model access).
+- Python 3.12, Node 22+, Docker.
+- AWS CLI, AWS SAM CLI (`brew install aws-sam-cli`), AWS CDK CLI (`npm install -g aws-cdk`).
+- AWS profile with the [permissions listed below](#minimum-aws-permissions), set in `.env` as `AWS_PROFILE=<your-profile>` (`cp .env.example .env` if you haven't).
 
-If you're using a dedicated locked-down dev user, also pair it with an AWS Budgets action so a leaked credential can't run up unbounded Bedrock spend — Bedrock has no per-principal cost cap.
-
-### Setup
+### One-time setup
 
 ```bash
-# 1. Create local-env.json from the example and fill in your values
+# 1. Python venv + deps.
+#    backend/shared brings in bcrypt (for hashing the local password).
+#    infrastructure brings in aws-cdk-lib (for `cdk synth`).
+python3.12 -m venv .venv
+source .venv/bin/activate
+pip install -r backend/shared/requirements.txt -r infrastructure/requirements.txt
+
+# 2. Frontend deps + Husky pre-push hook.
+cd frontend && npm install && cd ..
+
+# 3. Local env config.
 cp local-env.example.json local-env.json
 
-# 2. Generate a bcrypt hash of whatever password you want for local access
-source .venv/bin/activate
+#    a. Generate a bcrypt hash of whatever password you want for local access
+#       and paste the resulting $2b$12$… string into local-env.json as LOCAL_PASSWORD_HASH:
 python -c "import bcrypt; print(bcrypt.hashpw(b'pick-any-local-password', bcrypt.gensalt(12)).decode())"
-# → paste the resulting $2b$12$… string into local-env.json as LOCAL_PASSWORD_HASH
 
-# 3. Replace REPLACE_WITH_AWS_ACCOUNT_ID in local-env.json with your account ID:
+#    b. Replace REPLACE_WITH_AWS_ACCOUNT_ID in local-env.json with your account ID:
 aws sts get-caller-identity --query Account --output text --profile $AWS_PROFILE
+```
 
-# 4. Synth the CDK template (one-time, or after infra changes)
-cd infrastructure && cdk synth --profile $AWS_PROFILE && cd ..
+### Run
 
-# 5. Start local API gateway proxy + SAM local Lambda
+```bash
+# Terminal 1 — local API proxy + SAM Lambda runtime.
+# First run auto-synths the CDK template; later runs reuse the cached one.
 bash scripts/start-local.sh
 
-# 6. In another terminal:
+# Terminal 2 — Angular dev server.
 cd frontend && npm start    # http://localhost:4200
 ```
 
-Port 3000 is the proxy the frontend talks to; port 3001 is the SAM Lambda runtime. Code edits are picked up on the next request — infra changes (CDK) require re-running `cdk synth`. `local-env.json` is gitignored; setting `LOCAL_PASSWORD_HASH` lets the auth handler skip Secrets Manager so you don't need `secretsmanager:GetSecretValue` on your local IAM user.
+Port 3000 is the proxy the frontend talks to; port 3001 is the SAM Lambda runtime.
+
+### Day-to-day
+
+- **Backend code edits** are picked up on the next request — no restart needed.
+- **Infra edits** (anything under `infrastructure/`) require re-running `cdk synth` so SAM picks up the new template. `start-local.sh` only auto-synths when the template file is missing, so do this manually after pulling infra changes or editing CDK code:
+  ```bash
+  cd infrastructure && cdk synth --profile $AWS_PROFILE && cd ..
+  ```
+- **Frontend edits** hot-reload via the Angular dev server.
+- `local-env.json` is gitignored. Setting `LOCAL_PASSWORD_HASH` lets the auth handler skip Secrets Manager so your local IAM user does NOT need `secretsmanager:GetSecretValue`.
+
+### Minimum AWS permissions
+
+The IAM principal whose creds you're using locally needs:
+
+- `bedrock:InvokeModel` on the Claude Haiku/Opus model + inference-profile ARNs.
+- Read/write on the deployed `public-comment-analyzer-data-<env>-<account>` S3 bucket.
+- Read/write on the `PublicCommentAnalyzer-Jobs-<env>` DynamoDB table.
+- `ssm:GetParameter` on `/cdk-bootstrap/*` — only if you re-synth the CDK template locally.
+
+Bedrock model access for Claude Haiku and Claude Opus must also be enabled in your region (Console → Bedrock → Model access).
+
+If you're using a dedicated locked-down dev user, pair it with an AWS Budgets action so a leaked credential can't run up unbounded Bedrock spend — Bedrock has no per-principal cost cap.
 
 For test commands and the contribution workflow, see [CONTRIBUTING.md](./CONTRIBUTING.md).
 


### PR DESCRIPTION
## Summary

- Splits the **Local development** section into **Prereqs / One-time setup / Run / Day-to-day**, so a fresh contributor can follow it top-to-bottom without skipping back to the Quick start prereqs.
- Adds the missing `pip install -r backend/shared/requirements.txt -r infrastructure/requirements.txt` step. The old steps used `bcrypt` and assumed `cdk synth` would work, but never installed either.
- Adds explicit `python3.12 -m venv .venv` so we don't assume one exists.
- Drops the standalone `cdk synth` step — `scripts/start-local.sh` already auto-synths on first run when the template file is missing.
- Surfaces the staleness gotcha: `start-local.sh`'s check is "does the file exist," not "is it stale," so contributors must re-run `cdk synth` manually after pulling infra edits. This was buried in a trailing paragraph.
- Reorders so the IAM permissions and Bedrock budget warning sit *after* the working steps as reference material instead of interrupting setup.

Linked: [OAIP-89](https://ncdigitalservices.atlassian.net/browse/OAIP-89)

## Test plan

- [ ] Read the rewritten section top-to-bottom from the perspective of a fresh clone.
- [ ] Verify the `pip install -r backend/shared/requirements.txt -r infrastructure/requirements.txt` line installs both `bcrypt` and `aws-cdk-lib` cleanly into a fresh `.venv`.
- [ ] Confirm `bash scripts/start-local.sh` works on first run with no manual `cdk synth`.