### PR TITLE
OAIP-120: Clear all Dependabot + CodeQL/Checkmarx security alerts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ If you tune concurrency, change all three values (worker pool, reserved concurre
 - Stored format: **bcrypt** hash (e.g. `$2b$12$...`) in Secrets Manager under `PublicCommentAnalyzer-AccessPassword-<env>`.
 - Verified with `bcrypt.checkpw` (constant-time). Never use `==` or SHA-256 — both have appeared in this repo's history and were both wrong.
 - `validate_access_key` fails closed: if neither `ACCESS_PASSWORD_SECRET_NAME` nor `LOCAL_PASSWORD_HASH` is configured, every request is rejected.
-- Frontend stores the password in `sessionStorage` (clears on tab close), not `localStorage`. Do not regress this.
+- Frontend holds the access key **in memory only** on the root-scoped `AuthService` singleton (`auth.service.ts`) — never in `sessionStorage`/`localStorage`. This keeps the credential out of any JS-readable web storage (the prior `sessionStorage` approach tripped CodeQL `js/clear-text-storage-of-sensitive-data` / Checkmarx CWE-922). The `authInterceptor` reads the key via `AuthService.getAccessKey()`, not from storage. Trade-off: a full page reload clears it and re-shows the access gate — acceptable since job state isn't persisted across reloads either. Do not regress this back to web storage.
 
 ### Prompt injection
 User-supplied comment data is wrapped in `<comment_data>` tags with anti-injection framing. When you add new prompts, follow the same pattern:
@@ -226,7 +226,7 @@ aws cloudfront create-invalidation --distribution-id "$DIST_ID" --paths "/*" --p
 
 - **Don't store passwords as SHA-256 hashes.** Use bcrypt via `bcrypt.checkpw`. SHA-256 hashes were used historically and a literal password + hash leaked into git — both have been removed by `git filter-repo`.
 - **Don't `bypassSecurityTrustHtml` on AI output.** Use Angular's default sanitizer.
-- **Don't put the password (or anything else sensitive) in `localStorage`.** Use `sessionStorage`.
+- **Don't put the access key (or anything else sensitive) in `localStorage` or `sessionStorage`.** Hold it in memory on the `AuthService` singleton — web storage of the credential is flagged by CodeQL/Checkmarx (CWE-922).
 - **Don't pin Lambdas to Python 3.11 / AL2.** Modern wheels need glibc 2.28+.
 - **Don't return `True` when auth config is missing.** Always fail closed.
 - **Don't use `git filter-branch`.** Use `git filter-repo` (`brew install git-filter-repo`).

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4642,9 +4642,9 @@
       }
     },
     "node_modules/@npmcli/package-json/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5974,9 +5974,9 @@
       }
     },
     "node_modules/@tufjs/models/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7096,9 +7096,9 @@
       }
     },
     "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8126,21 +8126,22 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.6.5",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.5.tgz",
-      "integrity": "sha512-2RZdgEbXmp5+dVbRm0P7HQUImZpICccJy7rN7Tv+SFa55pH+lxnuw6/K1ZxxBfHoYpSkHLAO92oa8O4SwFXA2A==",
+      "version": "6.6.8",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.8.tgz",
+      "integrity": "sha512-2agL3ueZhqxoVrfmntO8yuVj+uNSlIOnhykYHk3Cq0ShYPdUjjUiSJrQvXjq01I9jAuI0Zl2YO8Evv5Mqytm5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.12",
         "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
         "accepts": "~1.3.4",
         "base64id": "2.0.0",
         "cookie": "~0.7.2",
         "cors": "~2.8.5",
         "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.18.3"
+        "ws": "~8.20.1"
       },
       "engines": {
         "node": ">=10.2.0"
@@ -8581,13 +8582,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
-      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -8614,9 +8615,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -9056,9 +9057,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.17",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.17.tgz",
-      "integrity": "sha512-FbJJNb/XgX7YW0hX/V8w5oYLztKEsRLykCMZWt1WdLtsfjzMvmoqWBA4H4t5norinq8/rh20oiZYr+WSl4UzAQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9357,9 +9358,9 @@
       }
     },
     "node_modules/ignore-walk/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9463,9 +9464,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10178,9 +10179,9 @@
       }
     },
     "node_modules/karma/node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10192,7 +10193,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -10343,22 +10344,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/karma/node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/karma/node_modules/raw-body": {
@@ -12493,9 +12478,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -13515,14 +13500,14 @@
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
-      "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.7.tgz",
+      "integrity": "sha512-e0LyK91f3cUxTmv95/KzoLg47+zF+s/sbxRGDNsyG4dmIP8ZSX8ax6byOxfJXeNNtS/8AZlfD+uP7gBeR7DLlg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "~4.4.1",
-        "ws": "~8.18.3"
+        "ws": "~8.20.1"
       }
     },
     "node_modules/socket.io-parser": {
@@ -14016,9 +14001,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14335,14 +14320,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-name": {
@@ -14562,9 +14550,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.3.tgz",
-      "integrity": "sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
+      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14658,22 +14646,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/webpack-dev-server/node_modules/body-parser/node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/webpack-dev-server/node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -14737,15 +14709,15 @@
       "license": "MIT"
     },
     "node_modules/webpack-dev-server/node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -14764,7 +14736,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -14976,22 +14948,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/webpack-dev-server/node_modules/raw-body": {
@@ -15313,9 +15269,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,5 +46,9 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
     "typescript": "~5.9.3"
+  },
+  "overrides": {
+    "uuid": "^11.1.1",
+    "webpack-dev-server": "^5.2.4"
   }
 }

--- a/frontend/src/app/interceptors/auth.interceptor.spec.ts
+++ b/frontend/src/app/interceptors/auth.interceptor.spec.ts
@@ -17,7 +17,8 @@ describe('authInterceptor', () => {
     sessionStorage.clear();
     localStorage.clear();
 
-    authServiceSpy = jasmine.createSpyObj<AuthService>('AuthService', ['logout']);
+    authServiceSpy = jasmine.createSpyObj<AuthService>('AuthService', ['logout', 'getAccessKey']);
+    authServiceSpy.getAccessKey.and.returnValue('');
 
     TestBed.configureTestingModule({
       providers: [
@@ -37,8 +38,8 @@ describe('authInterceptor', () => {
     localStorage.clear();
   });
 
-  it('attaches X-Access-Key from sessionStorage on protected requests', () => {
-    sessionStorage.setItem(STORAGE_KEY, 'session-password');
+  it('attaches X-Access-Key from AuthService on protected requests', () => {
+    authServiceSpy.getAccessKey.and.returnValue('session-password');
 
     http.get(`${API}/upload`).subscribe();
     const req = httpMock.expectOne(`${API}/upload`);
@@ -47,7 +48,7 @@ describe('authInterceptor', () => {
     req.flush({});
   });
 
-  it('does NOT attach X-Access-Key when sessionStorage is empty', () => {
+  it('does NOT attach X-Access-Key when AuthService has no key', () => {
     http.get(`${API}/upload`).subscribe();
     const req = httpMock.expectOne(`${API}/upload`);
 
@@ -55,10 +56,12 @@ describe('authInterceptor', () => {
     req.flush({});
   });
 
-  it('does NOT read from localStorage (storage source is pinned to sessionStorage)', () => {
-    // A localStorage value must not leak into the header. This guards against
-    // regressing commit d3bc1df, which moved auth.service.ts to sessionStorage
-    // but left the interceptor reading localStorage.
+  it('does NOT read the access key from web storage — AuthService is the only source', () => {
+    // The access key must never be sourced from sessionStorage/localStorage.
+    // Even when both contain a value, nothing is attached unless AuthService
+    // (in-memory) returns it. This guards against regressing back to a
+    // web-storage-backed credential (CodeQL js/clear-text-storage-of-sensitive-data).
+    sessionStorage.setItem(STORAGE_KEY, 'leaked-from-sessionstorage');
     localStorage.setItem(STORAGE_KEY, 'leaked-from-localstorage');
 
     http.get(`${API}/upload`).subscribe();
@@ -68,8 +71,8 @@ describe('authInterceptor', () => {
     req.flush({});
   });
 
-  it('does NOT attach X-Access-Key on /auth/validate even with sessionStorage set', () => {
-    sessionStorage.setItem(STORAGE_KEY, 'session-password');
+  it('does NOT attach X-Access-Key on /auth/validate even when a key is set', () => {
+    authServiceSpy.getAccessKey.and.returnValue('session-password');
 
     http.post(`${API}/auth/validate`, { password: 'foo' }).subscribe();
     const req = httpMock.expectOne(`${API}/auth/validate`);
@@ -79,7 +82,7 @@ describe('authInterceptor', () => {
   });
 
   it('calls AuthService.logout() when a protected request returns 401', () => {
-    sessionStorage.setItem(STORAGE_KEY, 'session-password');
+    authServiceSpy.getAccessKey.and.returnValue('session-password');
 
     http.get(`${API}/upload`).subscribe({
       next: () => fail('expected 401 error'),

--- a/frontend/src/app/interceptors/auth.interceptor.ts
+++ b/frontend/src/app/interceptors/auth.interceptor.ts
@@ -3,11 +3,11 @@ import { inject } from '@angular/core';
 import { tap } from 'rxjs/operators';
 import { AuthService } from '../services/auth.service';
 
-const ACCESS_KEY_STORAGE_KEY = 'pca_access_key';
-
 export const authInterceptor: HttpInterceptorFn = (req, next) => {
   const authService = inject(AuthService);
-  const accessKey = sessionStorage.getItem(ACCESS_KEY_STORAGE_KEY);
+  // AuthService holds the access key in memory only — it is the single source of
+  // truth. The interceptor never reads web storage directly.
+  const accessKey = authService.getAccessKey();
 
   // Don't attach the key to the auth/validate call itself
   if (accessKey && !req.url.includes('/auth/validate')) {

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -4,30 +4,35 @@ import { BehaviorSubject, Observable, of } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
 
-const ACCESS_KEY_STORAGE_KEY = 'pca_access_key';
-
 @Injectable({
   providedIn: 'root'
 })
 export class AuthService {
+  // The shared access key is held in memory only on this root-scoped singleton.
+  // It is deliberately NOT persisted to sessionStorage/localStorage so the
+  // credential never lands in any JS-readable web storage. The trade-off is that
+  // a full page reload clears it and the access gate is shown again — acceptable
+  // because job state is not persisted across reloads either.
+  private accessKey: string | null = null;
+
   private authenticatedSubject = new BehaviorSubject<boolean>(this.hasStoredKey());
   authenticated$ = this.authenticatedSubject.asObservable();
 
   constructor(private http: HttpClient) {}
 
   hasStoredKey(): boolean {
-    return !!sessionStorage.getItem(ACCESS_KEY_STORAGE_KEY);
+    return !!this.accessKey;
   }
 
   getAccessKey(): string {
-    return sessionStorage.getItem(ACCESS_KEY_STORAGE_KEY) || '';
+    return this.accessKey ?? '';
   }
 
   validate(password: string): Observable<boolean> {
     return this.http.post<{ valid: boolean }>(`${environment.apiBaseUrl}/auth/validate`, { password }).pipe(
       map(res => {
         if (res.valid) {
-          sessionStorage.setItem(ACCESS_KEY_STORAGE_KEY, password);
+          this.accessKey = password;
           this.authenticatedSubject.next(true);
         }
         return res.valid;
@@ -37,7 +42,7 @@ export class AuthService {
   }
 
   logout(): void {
-    sessionStorage.removeItem(ACCESS_KEY_STORAGE_KEY);
+    this.accessKey = null;
     this.authenticatedSubject.next(false);
   }
 }


### PR DESCRIPTION
## Why
Pre-release security scan for the open-source release (ESRMO SSPP gate) must pass **GitHub native scanning AND Checkmarx**. This clears every open alert.

## What
**Dependabot (12 npm alerts → 0)** — all were transitive, `development`-scope, in `frontend/package-lock.json`.
- `npm audit fix` (no `--force`) patched the in-range ones: fast-uri 3.1.2, tmp 0.2.7, hono 4.12.23, ip-address 10.2.0, qs 6.15.2, ws 8.20.1, brace-expansion 5.0.6, plus body-parser/express/express-rate-limit/engine.io/socket.io-adapter.
- Added `overrides` in `frontend/package.json` for the two that needed a forced bump:
  - `uuid ^11.1.1` — breaks the `uuid → sockjs → webpack-dev-server → @angular-devkit/build-angular` chain (sockjs only uses `uuid.v4()`, which v11 still exports in CJS — verified safe).
  - `webpack-dev-server ^5.2.4` — its own advisory (≤5.2.3) wasn't fixed by the chain.
- `npm audit` now reports **0 vulnerabilities**.

**CodeQL High / Checkmarx CWE-922** (`js/clear-text-storage-of-sensitive-data` in `auth.service.ts`) — real code fix, not a dismissal: the access key is now held **in memory only** on the root `AuthService` singleton and never written to `sessionStorage`/`localStorage`. The interceptor reads it via `AuthService.getAccessKey()`. This removes the storage sink entirely, so both scanners stop flagging it. Backend, CORS, and the `X-Access-Key` header model are unchanged. Trade-off: a full page reload re-shows the access gate (job state isn't persisted across reloads anyway).

## Verification
- `npm audit` → 0 vulnerabilities
- `npm run build:prod` → success
- `npm run test:ci` → **110/110 pass** (interceptor spec rewritten to the in-memory model; keeps the no-web-storage + no-key-on-/auth/validate + logout-on-401 guarantees)
- `grep` confirms no production code reads/writes the key in web storage

Closes OAIP-120.